### PR TITLE
Fixes to run react-native-desktop on Mac os

### DIFF
--- a/ReactQt/runtime/src/communication/serverconnection.cpp
+++ b/ReactQt/runtime/src/communication/serverconnection.cpp
@@ -30,7 +30,7 @@ QString itemWithPath(const QString& item, const QStringList& searchPaths) {
     }
     return item;
 }
-}
+} // namespace
 
 namespace {
 struct RegisterLocal {
@@ -44,7 +44,7 @@ struct RegisterRemote {
         qRegisterMetaType<RemoteServerConnection*>();
     }
 } registerRemote;
-}
+} // namespace
 
 ServerConnection::ServerConnection(QObject* parent) : QObject(parent) {}
 
@@ -109,7 +109,6 @@ RemoteServerConnection::RemoteServerConnection(QObject* parent) : ServerConnecti
 
     m_socket = new QTcpSocket(this);
     connect(m_socket, &QTcpSocket::readyRead, this, &RemoteServerConnection::dataReady);
-    connect(m_socket, &QTcpSocket::connected, [=]() { emit connectionReady(); });
     connect(m_socket,
             static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QAbstractSocket::error),
             [=](QAbstractSocket::SocketError) { emit connectionError(); });

--- a/ReactQt/runtime/src/communication/serverconnection.cpp
+++ b/ReactQt/runtime/src/communication/serverconnection.cpp
@@ -109,6 +109,7 @@ RemoteServerConnection::RemoteServerConnection(QObject* parent) : ServerConnecti
 
     m_socket = new QTcpSocket(this);
     connect(m_socket, &QTcpSocket::readyRead, this, &RemoteServerConnection::dataReady);
+    connect(m_socket, &QTcpSocket::connected, [=]() { emit connectionReady(); });
     connect(m_socket,
             static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QAbstractSocket::error),
             [=](QAbstractSocket::SocketError) { emit connectionError(); });

--- a/ReactQt/runtime/src/communication/serverconnection.h
+++ b/ReactQt/runtime/src/communication/serverconnection.h
@@ -68,7 +68,7 @@ private:
     virtual QIODevice* device();
 
 private:
-    QString m_serverHost = "localhost";
+    QString m_serverHost = "127.0.0.1";
     int m_port = 5000;
     QTcpSocket* m_socket = nullptr;
 };

--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -23,6 +23,7 @@
 #include "layout/flexbox.h"
 #include "propertyhandler.h"
 #include "textmanager.h"
+#include <cmath>
 
 TextManager::TextManager(QObject* parent) : RawTextManager(parent) {}
 

--- a/ReactQt/runtime/src/networking.cpp
+++ b/ReactQt/runtime/src/networking.cpp
@@ -31,7 +31,7 @@ QVariantMap headerListToMap(const QList<QNetworkReply::RawHeaderPair>& rawHeader
     }
     return rh;
 }
-}
+} // namespace
 
 class NetworkingPrivate {
 public:

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -68,7 +68,7 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
 QVariantMap makeReactTouchEvent(QQuickItem* item, QTouchEvent* event) {
     return QVariantMap{};
 }
-}
+} // namespace
 
 class RootViewPrivate : public QObject {
     Q_OBJECT
@@ -222,8 +222,7 @@ void RootView::loadBundle(const QString& moduleName, const QUrl& codeLocation) {
 }
 
 void RootView::updatePolish() {
-    if (childItems().count() > 0) {
-        Q_ASSERT(childItems().count() == 1);
+    if (childItems().count() == 1) {
         auto view = childItems().at(0);
         Flexbox* flexbox = Flexbox::findFlexbox(view);
         if (flexbox) {


### PR DESCRIPTION
### Errors fixed on mac
- "localhost" is unrecognized url on mac
- std::isnan requires including cmath header
- `RootView::updatePolish` called in integration test and failed when RedBox shown. On Ubuntu virtual machine we didn't have this error because due to rendering issues `updatePoslish` wasn't called. 

p.s. `//namespace` comment is automatically generated by latest clang-format on mac