### PR TITLE
refs #7 - Developer menu and Chrome Dev Tools support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
           sudo apt-get -qy update
           sudo apt-get install -y dbus xvfb curl cmake mesa-common-dev \
-              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative
+              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative qt59websockets
           echo "/opt/qt59/bin/qt59-env.sh" >> ~/.circlerc
 
       # Install node
@@ -52,11 +52,18 @@ jobs:
       # Repair dbus
       - run: ln -s /var/lib/dbus/machine-id /etc/machine-id
 
-      # Build react-native-linux
+      # Build react-native-desktop in Debug (RCT_DEV enabled)
+      - run: |
+          mkdir build_debug
+          pushd build_debug
+          cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j4
+          popd
+
+      # Build react-native-desktop in Release
       - run: |
           mkdir build
           pushd build
-          cmake .. && make -j4
+          cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4
           popd
 
       # Download and cache dependencies

--- a/Examples/Example.qml.in
+++ b/Examples/Example.qml.in
@@ -1,5 +1,5 @@
 
-import QtQuick 2.4
+import QtQuick 2.7
 import React 0.1 as React
 
 Rectangle {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Used Qt framework of version Qt 5.9.1 LTS.
 
 Follow [Ubuntu development guide](https://github.com/status-im/react-native-desktop/blob/react-native-qt/README-ubuntu.md) to get started buiding of react-native-desktop itself and JS apps based on it.
 
+### Debugging
+
+To access `In-App Developer Menu` ~~start shaking your laptop/PC~~ press CTRL+R.  
+By default, `In-App Developer Menu` is available only for Debug configuration builds.
+
 ## Documentation
 
 - [List of supported React Native componenets and APIs ("React Native Qt" column)](https://github.com/status-im/react-native-desktop/blob/react-native-qt/docs/ReactQt/ComponentsSupport.md)

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -15,6 +15,10 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Qml REQUIRED)
 find_package(Qt5Quick REQUIRED)
 
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  find_package(Qt5WebSockets REQUIRED)
+endif()
+
 
 configure_file(
   main.qml.in
@@ -29,7 +33,12 @@ add_executable(
   main.qrc
 )
 
-qt5_use_modules(${APP_NAME} Core Qml Quick)
+set(USED_QT_MODULES Core Qml Quick)
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  set(USED_QT_MODULES ${USED_QT_MODULES} WebSockets)
+endif()
+
+qt5_use_modules(${APP_NAME} ${USED_QT_MODULES})
 
 target_link_libraries(
   ${APP_NAME}

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -12,9 +12,17 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
 
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  ADD_DEFINITIONS(-DRCT_DEV)
+endif()
+
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Qml REQUIRED)
 find_package(Qt5Quick REQUIRED)
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  find_package(Qt5WebSockets REQUIRED)
+endif()
 
 set(
   SRC
@@ -57,7 +65,9 @@ set(
   layout/flexbox.cpp
   utilities.cpp
   communication/serverconnection.cpp
-  communication/executor
+  communication/executor.cpp
+  communication/websocketexecutor.cpp
+  communication/iexecutor.h
   ../../../ReactCommon/yoga/yoga/Yoga.c
   ../../../ReactCommon/yoga/yoga/YGEnums.c
   ../../../ReactCommon/yoga/yoga/YGNodeList.c
@@ -76,6 +86,7 @@ set(
   qml/ReactButton.qml
   qml/ReactSlider.qml
   qml/ReactModal.qml
+  qml/DevMenu.qml
 )
 
 if(DEFINED REACT_BUILD_STATIC_LIB)
@@ -98,7 +109,12 @@ set_target_properties(
 )
 endif()
 
-qt5_use_modules(react-native Core Qml Quick)
+set(USED_QT_MODULES Core Qml Quick)
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  set(USED_QT_MODULES ${USED_QT_MODULES} WebSockets)
+endif()
+
+qt5_use_modules(react-native ${USED_QT_MODULES})
 
 add_custom_target(
   copy-qmldir ALL

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -91,6 +91,7 @@ public:
     TestModule* testModule() const;
     ImageLoader* imageLoader() const;
     RedboxItem* redbox();
+    void setRemoteJSDebugging(bool value);
 
 Q_SIGNALS:
     void readyChanged();

--- a/ReactQt/runtime/src/communication/executor.cpp
+++ b/ReactQt/runtime/src/communication/executor.cpp
@@ -41,7 +41,7 @@ public:
     Executor* q_ptr = nullptr;
 };
 
-Executor::Executor(ServerConnection* conn, QObject* parent) : QObject(parent), d_ptr(new ExecutorPrivate(this)) {
+Executor::Executor(ServerConnection* conn, QObject* parent) : IExecutor(parent), d_ptr(new ExecutorPrivate(this)) {
     Q_ASSERT(conn);
     Q_D(Executor);
     d->m_connection = QSharedPointer<ServerConnection>(conn);
@@ -50,7 +50,9 @@ Executor::Executor(ServerConnection* conn, QObject* parent) : QObject(parent), d
     d->setupStateMachine();
 }
 
-Executor::~Executor() {}
+Executor::~Executor() {
+    d_ptr->connection()->device()->close();
+}
 
 void ExecutorPrivate::setupStateMachine() {
     m_machina = new QStateMachine(this);

--- a/ReactQt/runtime/src/communication/iexecutor.h
+++ b/ReactQt/runtime/src/communication/iexecutor.h
@@ -1,0 +1,45 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef IEXECUTOR_H
+#define IEXECUTOR_H
+
+#include <functional>
+
+#include <QByteArray>
+#include <QObject>
+#include <QVariant>
+
+class IExecutor : public QObject {
+    Q_OBJECT
+
+public:
+    typedef std::function<void(const QJsonDocument&)> ExecuteCallback;
+
+    IExecutor(QObject* parent = nullptr) : QObject(parent) {}
+    virtual ~IExecutor() {}
+
+    virtual void init() = 0;
+
+    virtual void injectJson(const QString& name, const QVariant& data) = 0;
+    virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl) = 0;
+    virtual void executeJSCall(const QString& method,
+                               const QVariantList& args = QVariantList(),
+                               const ExecuteCallback& callback = ExecuteCallback()) = 0;
+
+Q_SIGNALS:
+    // TODO: KOZIEIEV: remove from Executor. Maybe in Bridge. Executor shouldn't know about app-related things.
+    void applicationScriptDone();
+
+    void commandReceived(int size);
+};
+
+#endif // IEXECUTOR_H

--- a/ReactQt/runtime/src/communication/websocketexecutor.cpp
+++ b/ReactQt/runtime/src/communication/websocketexecutor.cpp
@@ -1,0 +1,201 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifdef RCT_DEV
+
+#include "websocketexecutor.h"
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QQueue>
+#include <QTimer>
+#include <QWebSocket>
+
+namespace {
+const int CHROME_DEV_TOOL_AWAIT_TIMEOUT = 5000;
+}
+
+class WebSocketExecutorPrivate : public QObject {
+public:
+    WebSocketExecutorPrivate(WebSocketExecutor* e) : q_ptr(e) {}
+
+    bool processRequests();
+    void processRequest(const QByteArray& request,
+                        const IExecutor::ExecuteCallback& callback = IExecutor::ExecuteCallback());
+    void setupWebSocket(const QUrl& url);
+    QByteArray getMessageData(const QVariantMap& messageData);
+
+public slots:
+    void readReply(const QString& reply);
+    void passReceivedDataToCallback(const QByteArray& data);
+
+public:
+    QQueue<QByteArray> m_requestQueue;
+    QQueue<IExecutor::ExecuteCallback> m_responseQueue;
+    QByteArray m_inputBuffer;
+    WebSocketExecutor* q_ptr = nullptr;
+    QWebSocket m_webSocket;
+    QVariantMap m_injectedObjects;
+    bool m_readyToSendAppScriptData = false;
+    QByteArray m_applicationScriptData;
+};
+
+WebSocketExecutor::WebSocketExecutor(const QUrl& url, QObject* parent)
+    : IExecutor(parent), d_ptr(new WebSocketExecutorPrivate(this)) {
+    Q_D(WebSocketExecutor);
+
+    d->setupWebSocket(url);
+}
+
+WebSocketExecutor::~WebSocketExecutor() {}
+
+void WebSocketExecutorPrivate::setupWebSocket(const QUrl& url) {
+
+    connect(&m_webSocket, &QWebSocket::connected, [=]() {
+        QUrl startDevToolsURL = url.resolved(QStringLiteral("launch-js-devtools"));
+        startDevToolsURL.setScheme("http");
+        QNetworkAccessManager* networkAccessManager = new QNetworkAccessManager();
+        QNetworkReply* reply = networkAccessManager->get(QNetworkRequest(startDevToolsURL));
+
+        connect(reply, &QNetworkReply::readyRead, [=]() {
+            if (reply->readAll() == QStringLiteral("OK")) {
+                QTimer* timer = new QTimer;
+                timer->setSingleShot(true);
+                timer->setInterval(CHROME_DEV_TOOL_AWAIT_TIMEOUT);
+
+                QObject::connect(timer, &QTimer::timeout, [=]() {
+                    QByteArray data = getMessageData(QVariantMap{{"method", "prepareJSRuntime"}});
+                    processRequest(data, [=](const QJsonDocument&) {
+                        m_readyToSendAppScriptData = true;
+                        q_ptr->executeApplicationScriptOnSocketReady();
+                    });
+                    timer->deleteLater();
+                });
+                timer->start();
+            }
+            reply->abort();
+        });
+
+        connect(reply, &QNetworkReply::finished, [=]() {
+            reply->deleteLater();
+            networkAccessManager->deleteLater();
+        });
+    });
+
+    connect(&m_webSocket,
+            static_cast<void (QWebSocket::*)(QAbstractSocket::SocketError)>(&QWebSocket::error),
+            [=](QAbstractSocket::SocketError) { qDebug() << m_webSocket.errorString(); });
+
+    connect(&m_webSocket, &QWebSocket::textMessageReceived, this, &WebSocketExecutorPrivate::readReply);
+
+    m_webSocket.open(url);
+}
+
+void WebSocketExecutor::injectJson(const QString& name, const QVariant& data) {
+    QJsonDocument doc = QJsonDocument::fromVariant(data);
+    d_ptr->m_injectedObjects[name] = doc.toJson(QJsonDocument::Compact);
+}
+
+void WebSocketExecutor::executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl) {
+    QVariantMap message = QVariantMap{
+        {"method", "executeApplicationScript"}, {"url", sourceUrl.toString()}, {"inject", d_ptr->m_injectedObjects}};
+    d_ptr->m_applicationScriptData = d_ptr->getMessageData(message);
+    executeApplicationScriptOnSocketReady();
+}
+
+void WebSocketExecutor::executeJSCall(const QString& method,
+                                      const QVariantList& args,
+                                      const IExecutor::ExecuteCallback& callback) {
+
+    QVariantMap message = QVariantMap{{"method", method}, {"arguments", args}};
+    QByteArray data = d_ptr->getMessageData(message);
+
+    d_ptr->processRequest(data, callback);
+}
+
+void WebSocketExecutor::init() {}
+
+QByteArray WebSocketExecutorPrivate::getMessageData(const QVariantMap& messageData) {
+    static int lastId = 10000;
+
+    QVariantMap data = messageData;
+    data["id"] = lastId++;
+    QJsonDocument doc = QJsonDocument::fromVariant(data);
+
+    return doc.toJson(QJsonDocument::Compact);
+}
+
+void WebSocketExecutor::executeApplicationScriptOnSocketReady() {
+    // JS source code should be loaded from bundler and WebSocket should be ready
+    // to send requests to JS side
+    if (d_ptr->m_readyToSendAppScriptData && !d_ptr->m_applicationScriptData.isEmpty()) {
+        d_ptr->processRequest(d_ptr->m_applicationScriptData,
+                              [=](const QJsonDocument&) { Q_EMIT applicationScriptDone(); });
+        d_ptr->m_applicationScriptData.clear();
+    }
+}
+
+bool WebSocketExecutorPrivate::processRequests() {
+    if (m_webSocket.state() != QAbstractSocket::ConnectedState || m_requestQueue.isEmpty()) {
+        return false;
+    }
+
+    QByteArray request = m_requestQueue.dequeue();
+    m_webSocket.sendTextMessage(request);
+    m_webSocket.flush();
+    return true;
+}
+
+void WebSocketExecutorPrivate::readReply(const QString& reply) {
+    passReceivedDataToCallback(reply.toLatin1());
+}
+
+void WebSocketExecutorPrivate::passReceivedDataToCallback(const QByteArray& data) {
+    if (m_responseQueue.size()) {
+        IExecutor::ExecuteCallback callback = m_responseQueue.dequeue();
+        if (callback) {
+            QJsonDocument doc;
+            if (data != "undefined") {
+                QJsonParseError error;
+                doc = QJsonDocument::fromJson(data, &error);
+                qDebug() << "Input Json document: " << doc << " Error: " << error.errorString();
+
+                // Try to extract "result" value and pass it to callback
+                QJsonValue resultValue = doc.object().value("result");
+                if (resultValue.isString()) {
+                    QString jsonArrayString = resultValue.toString();
+                    doc = QJsonDocument::fromJson(jsonArrayString.toLatin1(), &error);
+                }
+
+                qDebug() << "Result Json document: " << doc << " Error: " << error.errorString();
+            }
+            callback(doc);
+        }
+    }
+}
+
+void WebSocketExecutorPrivate::processRequest(const QByteArray& request, const IExecutor::ExecuteCallback& callback) {
+
+    m_requestQueue.enqueue(request);
+    m_responseQueue.enqueue(callback);
+
+    while (!m_requestQueue.isEmpty() && !m_responseQueue.isEmpty()) {
+        if (!processRequests())
+            break;
+    }
+}
+
+#endif // RCT_DEV

--- a/ReactQt/runtime/src/communication/websocketexecutor.h
+++ b/ReactQt/runtime/src/communication/websocketexecutor.h
@@ -1,37 +1,35 @@
 
 /**
- * Copyright (C) 2016, Canonical Ltd.
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * Author: Justin McPherson <justin.mcpherson@canonical.com>
- *
  */
 
-#ifndef EXECUTOR_H
-#define EXECUTOR_H
+#ifndef WEBSOCKETEXECUTOR_H
+#define WEBSOCKETEXECUTOR_H
 
-#include <QByteArray>
-#include <QIODevice>
-#include <QQueue>
-#include <QStateMachine>
+#ifdef RCT_DEV
+
+#include <functional>
+
+#include <QUrl>
 
 #include "iexecutor.h"
-#include "serverconnection.h"
 
-class ExecutorPrivate;
-class Executor : public IExecutor {
+class WebSocketExecutorPrivate;
+class WebSocketExecutor : public IExecutor {
     Q_OBJECT
-    Q_DECLARE_PRIVATE(Executor)
+    Q_DECLARE_PRIVATE(WebSocketExecutor)
 
 public:
     typedef std::function<void(const QJsonDocument&)> ExecuteCallback;
 
-    Executor(ServerConnection* conn, QObject* parent = nullptr);
-    ~Executor();
+    WebSocketExecutor(const QUrl& url, QObject* parent = nullptr);
+    ~WebSocketExecutor();
 
     virtual void init();
 
@@ -41,8 +39,12 @@ public:
                                const QVariantList& args = QVariantList(),
                                const ExecuteCallback& callback = ExecuteCallback());
 
+    void executeApplicationScriptOnSocketReady();
+
 private:
-    QScopedPointer<ExecutorPrivate> d_ptr;
+    QScopedPointer<WebSocketExecutorPrivate> d_ptr;
 };
 
-#endif // EXECUTOR_H
+#endif // RCT_DEV
+
+#endif // WEBSOCKETEXECUTOR_H

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -134,17 +134,9 @@ int ViewManager::tag(QQuickItem* view) const {
 }
 
 QQuickItem* ViewManager::createView() const {
-    QQmlComponent component(m_bridge->qmlEngine());
-    auto file = qmlComponentFile();
-    component.loadUrl(QUrl(file));
-    if (!component.isReady()) {
-        qCritical() << QString("Component for %1 is not ready!").arg(qmlComponentFile()) << component.errors();
-        return nullptr;
-    }
-
-    QQuickItem* item = qobject_cast<QQuickItem*>(component.create());
+    QQuickItem* item = createQMLItemFromSourceFile(m_bridge->qmlEngine(), QUrl(qmlComponentFile()));
     if (item == nullptr) {
-        qCritical() << QString("Unable to construct item from component %1").arg(qmlComponentFile());
+        qCritical() << QString("Can't create QML item for componenet %1").arg(qmlComponentFile());
     }
     return item;
 }

--- a/ReactQt/runtime/src/qml/DevMenu.qml
+++ b/ReactQt/runtime/src/qml/DevMenu.qml
@@ -1,0 +1,76 @@
+
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+
+Rectangle {
+    id: devMenuRootId
+    anchors.fill: parent
+    color: "transparent"
+    property var rootView: null
+
+    Rectangle {
+        id: devMenuId
+        anchors.top: parent.bottom
+        anchors.margins: 50
+        anchors.horizontalCenter: parent.horizontalCenter
+        color: "grey"
+        opacity: 0.8
+        width: devMenuColumnId.width + 100
+        height: devMenuColumnId.height + 100
+        Column {
+            id: devMenuColumnId
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 20
+            Button {
+                text: "Reload"
+                highlighted: true
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottomMargin: 10
+                onClicked: {
+                    devMenuRootId.state = "devMenuHidden"
+                    rootView.reloadBridge()
+                }
+            }
+            Button {
+                text: "Remote JS Debugging"
+                highlighted: true
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottomMargin: 10
+                onClicked: {
+                    devMenuRootId.state = "devMenuHidden"
+                    rootView.startRemoteJSDebugging()
+                }
+            }
+        }
+    }
+
+    states: [
+        State {
+            name: "devMenuVisible"
+            AnchorChanges { target: devMenuId; anchors.top: devMenuRootId.top; anchors.verticalCenter: devMenuRootId.verticalCenter }
+            PropertyChanges {
+                target: devMenuId
+                visible: true
+            }
+        },
+        State {
+            name: "devMenuHidden"
+            AnchorChanges { target: devMenuId; anchors.top: devMenuRootId.bottom; anchors.verticalCenter: undefined }
+            PropertyChanges {
+                target: devMenuId
+                visible: false
+            }
+        }
+    ]
+
+    transitions: Transition {
+        // devMenuId reanchoring animation
+        AnchorAnimation { duration: 200 }
+    }
+
+    Shortcut {
+        sequence: "Ctrl+R"
+        onActivated: devMenuRootId.state = "devMenuVisible"
+    }
+}

--- a/ReactQt/runtime/src/react_resources.qrc
+++ b/ReactQt/runtime/src/react_resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file>qml/DevMenu.qml</file>
         <file>qml/ReactImage.qml</file>
         <file>qml/ReactView.qml</file>
         <file>qml/ReactNavigator.qml</file>

--- a/ReactQt/runtime/src/redboxitem.cpp
+++ b/ReactQt/runtime/src/redboxitem.cpp
@@ -15,6 +15,7 @@
 
 #include "bridge.h"
 #include "redboxitem.h"
+#include "utilities.h"
 
 namespace {
 
@@ -76,12 +77,9 @@ public:
     }
 
     void createRedboxItem(QQuickItem* parent) {
-
-        QQmlComponent component(bridge->qmlEngine());
-        component.loadUrl(QUrl("qrc:/qml/ReactRedboxItem.qml"));
-        redbox = qobject_cast<QQuickItem*>(component.create());
+        redbox = utilities::createQMLItemFromSourceFile(bridge->qmlEngine(), QUrl("qrc:/qml/ReactRedboxItem.qml"));
         if (redbox == nullptr) {
-            qCritical() << __PRETTY_FUNCTION__ << "Unable to create RedboxItem" << component.errors();
+            qCritical() << __PRETTY_FUNCTION__ << "Unable to create RedboxItem";
             return;
         }
 

--- a/ReactQt/runtime/src/rootview.h
+++ b/ReactQt/runtime/src/rootview.h
@@ -62,6 +62,9 @@ public:
 
     void loadBundle(const QString& moduleName, const QUrl& codeLocation);
 
+    Q_INVOKABLE void startRemoteJSDebugging();
+    Q_INVOKABLE void reloadBridge();
+
 Q_SIGNALS:
     void liveReloadChanged();
     void moduleNameChanged();
@@ -84,6 +87,9 @@ private:
     void mouseReleaseEvent(QMouseEvent* event) override;
     bool childMouseEventFilter(QQuickItem* item, QEvent* event) override;
     void sendMouseEvent(QMouseEvent* event, const QString& eventType, QQuickItem* receiver);
+#ifdef RCT_DEV
+    void loadDevMenu();
+#endif // RCT_DEV
 
     QScopedPointer<RootViewPrivate> d_ptr;
 };

--- a/ReactQt/runtime/src/uimanager.cpp
+++ b/ReactQt/runtime/src/uimanager.cpp
@@ -384,9 +384,23 @@ UIManager::~UIManager() {
 }
 
 void UIManager::reset() {
+    // Avoid to delete root view on reset
+    QQuickItem* rootView = nullptr;
+    if (m_rootTag != -1 && m_views.contains(m_rootTag)) {
+        rootView = m_views[m_rootTag];
+        if (rootView) {
+            m_views.remove(m_rootTag);
+        }
+    }
+
     for (auto& v : m_views) {
         v->setParentItem(nullptr);
         v->deleteLater();
+    }
+    m_views.clear();
+
+    if (rootView) {
+        m_views.insert(m_rootTag, rootView);
     }
     m_bridge->visualParent()->polish();
 }
@@ -481,7 +495,8 @@ int UIManager::allocateRootTag() {
 
 void UIManager::registerRootView(QQuickItem* root) {
     AttachedProperties* properties = AttachedProperties::get(root);
-    m_views.insert(properties->tag(), root);
+    m_rootTag = properties->tag();
+    m_views.insert(m_rootTag, root);
 }
 
 QQuickItem* UIManager::viewForTag(int reactTag) {

--- a/ReactQt/runtime/src/uimanager.h
+++ b/ReactQt/runtime/src/uimanager.h
@@ -22,6 +22,7 @@
 
 class Bridge;
 class ComponentData;
+class QQuickItem;
 
 class UIManager : public QObject, public ModuleInterface {
     Q_OBJECT
@@ -94,6 +95,7 @@ private:
     Bridge* m_bridge;
     QMap<QString, ComponentData*> m_componentData;
     QMap<int, QQuickItem*> m_views;
+    int m_rootTag = -1;
 };
 
 #endif // UIMANAGER_H

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -59,4 +59,18 @@ QString normalizeInputEventName(const QString& eventName) {
 
     return tmp;
 }
+
+QQuickItem* createQMLItemFromSourceFile(QQmlEngine* qmlEngine, const QUrl& fileUrl) {
+    QQmlComponent component(qmlEngine);
+    component.loadUrl(fileUrl);
+    if (!component.isReady()) {
+        qCritical() << QString("Component for %1 is not loaded").arg(fileUrl.toString());
+    }
+
+    QQuickItem* item = qobject_cast<QQuickItem*>(component.create());
+    if (item == nullptr) {
+        qCritical() << QString("Unable to construct item from component %1").arg(fileUrl.toString());
+    }
+    return item;
+}
 }

--- a/ReactQt/runtime/src/utilities.h
+++ b/ReactQt/runtime/src/utilities.h
@@ -13,11 +13,16 @@
 #define UTILITIES
 
 #include <QString>
+#include <QUrl>
+
+class QQuickItem;
+class QQmlEngine;
 
 namespace utilities {
 
 void registerReactTypes();
 QString normalizeInputEventName(const QString& eventName);
+QQuickItem* createQMLItemFromSourceFile(QQmlEngine* qmlEngine, const QUrl& fileUrl);
 }
 
 #endif // UTILITIES


### PR DESCRIPTION
- Developer menu functionality is compiled under RCT_DEV define and by default available only in Debug builds.
- Developer menu is loaded dynamically from DevMenu.qml as direct child of top root QML item.
- CTRL+R shortcut is used to show developer menu
- WebSocketExecutor class is added to communicate between native app and Chrome Dev Tools via packager (similar to RCTWebSocketExecutor.m on iOS ); IExecutor interface is back to provide similar interface for executors.
- Chrome browser seems should be installed.
- Debugging workflow: 1. Start app built in Debug. 2. Press CTRL+R and Developer menu should appear. 3. Select "Remote JS Debugging". 4. Chrome Browser tab will be opened automatically and finally status of debugging session in Browser tab should change to active (something like Status: Debugger session #10001 active.). 5. Now it's possible to press CTRL+SHIFT+J in Chrome Browser Tab, select Sources in appeared developers panel, browse to JS sources of application to put breakpoints, etc.