### PR TITLE
refs #131 - External modules support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ set(PROJECT_VERSION "0.0.1")
 include_directories(./React/Layout)
 enable_testing()
 
+message(STATUS "External modules dirs: ${EXTERNAL_MODULES_DIR}")
+
+foreach(module_directory ${EXTERNAL_MODULES_DIR})
+  message(STATUS "Add external module subdirectory: ${module_directory}")
+  add_subdirectory(${module_directory})
+endforeach(loop_var)
+
 add_subdirectory(ReactQt)
 add_subdirectory(Examples)
 add_subdirectory(RNTester)

--- a/Examples/Example.qml.in
+++ b/Examples/Example.qml.in
@@ -11,5 +11,6 @@ Rectangle {
 
     moduleName: "${EXAMPLE_NAME}App"
     codeLocation: "http://localhost:8081/Examples/${EXAMPLE_NAME}/${EXAMPLE_NAME}App.bundle?platform=desktop&dev=true"
+    externalModules: []
   }
 }

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -19,6 +19,8 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   find_package(Qt5WebSockets REQUIRED)
 endif()
 
+# Format EXTERNAL_MODULES to contain array of external modules type names defined as strings
+string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}")
 
 configure_file(
   main.qml.in

--- a/ReactQt/application/src/main.qml
+++ b/ReactQt/application/src/main.qml
@@ -24,5 +24,6 @@ Rectangle {
     codeLocation: ReactNativeProperties.codeLocation
     pluginsPath: ReactNativeProperties.pluginsPath
     serverConnectionType: ReactNativeProperties.executor
+    externalModules: []
   }
 }

--- a/ReactQt/application/src/main.qml.in
+++ b/ReactQt/application/src/main.qml.in
@@ -24,5 +24,6 @@ Rectangle {
     codeLocation: ReactNativeProperties.codeLocation
     pluginsPath: ReactNativeProperties.pluginsPath
     serverConnectionType: ReactNativeProperties.executor
+    externalModules: [${EXTERNAL_MODULES}]
   }
 }

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -25,7 +25,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 endif()
 
 set(
-  SRC
+  SRC_RUNTIME
   reactplugin.cpp
   valuecoercion.cpp
   blobprovider.cpp
@@ -72,6 +72,10 @@ set(
   ../../../ReactCommon/yoga/yoga/YGEnums.c
   ../../../ReactCommon/yoga/yoga/YGNodeList.c
 )
+
+message(STATUS "REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC = ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC}")
+
+set (SRC ${SRC_RUNTIME} ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC})
 
 set(
   QML

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -85,6 +85,9 @@ public:
     QString serverConnectionType() const;
     void setServerConnectionType(const QString& serverConnectionType);
 
+    const QVariantList& externalModules() const;
+    void setExternalModules(const QVariantList& externalModules);
+
     EventDispatcher* eventDispatcher() const;
     QList<ModuleData*> modules() const;
     UIManager* uiManager() const;
@@ -105,6 +108,7 @@ private Q_SLOTS:
 private:
     void loadSource();
     void initModules();
+    void loadExternalModules(QObjectList* modules);
     void injectModules();
     void processResult(const QJsonDocument& document);
     void setupExecutor();

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -208,6 +208,18 @@ void RootView::setServerConnectionType(const QString& executor) {
     Q_EMIT executorChanged();
 }
 
+QVariantList RootView::externalModules() const {
+    return d_func()->bridge->externalModules();
+}
+
+void RootView::setExternalModules(const QVariantList& externalModules) {
+    Q_D(RootView);
+    if (bridge()->externalModules() == externalModules)
+        return;
+    bridge()->setExternalModules(externalModules);
+    Q_EMIT externalModulesChanged();
+}
+
 Bridge* RootView::bridge() const {
     return d_func()->bridge;
 }

--- a/ReactQt/runtime/src/rootview.h
+++ b/ReactQt/runtime/src/rootview.h
@@ -33,6 +33,7 @@ class RootView : public ReactItem {
     Q_PROPERTY(QString pluginsPath READ pluginsPath WRITE setPluginsPath NOTIFY pluginsPathChanged)
     Q_PROPERTY(
         QString serverConnectionType READ serverConnectionType WRITE setServerConnectionType NOTIFY executorChanged)
+    Q_PROPERTY(QVariantList externalModules READ externalModules WRITE setExternalModules NOTIFY externalModulesChanged)
 
     Q_DECLARE_PRIVATE(RootView)
 
@@ -58,6 +59,9 @@ public:
     QString serverConnectionType() const;
     void setServerConnectionType(const QString& serverConnectionType);
 
+    QVariantList externalModules() const;
+    void setExternalModules(const QVariantList& externalModules);
+
     Bridge* bridge() const;
 
     void loadBundle(const QString& moduleName, const QUrl& codeLocation);
@@ -72,6 +76,7 @@ Q_SIGNALS:
     void propertiesChanged();
     void pluginsPathChanged();
     void executorChanged();
+    void externalModulesChanged();
 
 protected:
     virtual void updatePolish() override;

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -73,4 +73,17 @@ QQuickItem* createQMLItemFromSourceFile(QQmlEngine* qmlEngine, const QUrl& fileU
     }
     return item;
 }
+
+QObject* createQObjectInstance(const QString& typeName) {
+    const int connectionType = QMetaType::type((typeName + "*").toLocal8Bit());
+    if (connectionType == QMetaType::UnknownType) {
+        return nullptr;
+    }
+    const QMetaObject* mObj = QMetaType::metaObjectForType(connectionType);
+    if (mObj == nullptr) {
+        return nullptr;
+    }
+    return mObj->newInstance();
+}
+
 } // namespace utilities

--- a/ReactQt/runtime/src/utilities.h
+++ b/ReactQt/runtime/src/utilities.h
@@ -23,6 +23,7 @@ namespace utilities {
 void registerReactTypes();
 QString normalizeInputEventName(const QString& eventName);
 QQuickItem* createQMLItemFromSourceFile(QQmlEngine* qmlEngine, const QUrl& fileUrl);
+QObject* createQObjectInstance(const QString& typeName);
 
 } // namespace utilities
 

--- a/local-cli/generate/generate.js
+++ b/local-cli/generate/generate.js
@@ -25,7 +25,7 @@ function generate(argv, config) {
 function _generate(argv, config, resolve, reject) {
   const args = parseCommandLine([{
     command: 'platform',
-    description: 'Platform (ios|android|ubuntu)',
+    description: 'Platform (ios|android|desktop)',
     type: 'string',
     required: true,
   },

--- a/local-cli/generator-desktop/templates/CMakeLists.txt
+++ b/local-cli/generator-desktop/templates/CMakeLists.txt
@@ -11,6 +11,13 @@ cmake_minimum_required(VERSION 2.8.11)
 set(APP_NAME <%= name %>)
 set(REACT_BUILD_STATIC_LIB ON)
 
+message(STATUS "EXTERNAL_MODULES_DIR: ${EXTERNAL_MODULES_DIR}")
+
+foreach(external_module ${EXTERNAL_MODULES_DIR})
+  message(STATUS "external_module: ${external_module}")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../${external_module} ${CMAKE_CURRENT_BINARY_DIR}/${external_module})
+endforeach(external_module)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/React/Layout)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/runtime/src ${CMAKE_CURRENT_BINARY_DIR}/lib)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/application/src ${CMAKE_CURRENT_BINARY_DIR}/bin)

--- a/local-cli/generator-desktop/templates/build.sh
+++ b/local-cli/generator-desktop/templates/build.sh
@@ -9,11 +9,14 @@
 
 # XXX: Don't move this script
 cd $(dirname $0)
+externalModulesPaths="$1"
+
+echo $externalModulesPaths
 
 # Workaround
 rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile
 
 # Build project
-cmake . && make && cp ./bin/<%= name %> click/
+cmake -DEXTERNAL_MODULES_DIR="$externalModulesPaths" . && make && cp ./bin/<%= name %> click/
 
 


### PR DESCRIPTION
- Application based on react-native-desktop can be extended with external native modules by adding array of external modules paths to package.json (Custom variable `desktopExternalModules`)
- `react-native run-desktop` command process `desktopExternalModules` from package.json and passes values to CMake build script.
- CMake build script updated to support EXTERNAL_MODULES_DIR input param with list of external modules paths. Each external module directory should contain its own CMakeLists.txt script which extends REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC variable with corresponding module C++ source files and also extends REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES variable with external modules C++ classes type names.
- List of external modules can be passed to RootView instance directly in QML code using property `externalModules`
- Each C++ native module class should be inherited from QObject and from ModuleInterface. It should register itself within Qt metadata system and has default constructor defined with Q_INVOKABLE.
- Bridge instantiate C++ classes based on their type names received from `externalModules` property. Since instantiating based on QMetaType system, C++ native module classes should meet requirements described above.

----------------------------------------------

There is available test branch with added ExternalTestModule and ExternalTestModule2: https://github.com/MaxRis/react-native-desktop/tree/feature/test-3rd-party-modules-support-%23131

package.json of custom application should be extended with
```
,
  "desktopExternalModules": [
    "node_modules/react-native/ExternalTestModule",
    "node_modules/react-native/ExternalTestModule2"
  ]
```

JS code can reference and call external modules as following:

```
var ReactNative = require('react-native');
var { ExternalTestModule, ExternalTestModule2 } = ReactNative.NativeModules;
...
  render() {
    return (
      <View style={styles.container}>
        <Text style={styles.welcome}>
          Welcome to React Native!
          {ExternalTestModule.sayHello}
          {ExternalTestModule2.sayHello}
        </Text>
      </View>
    );
  }
```