### PR TITLE
Live Reload added to Developer Menu #155

### DIFF
--- a/ReactQt/runtime/src/qml/DevMenu.qml
+++ b/ReactQt/runtime/src/qml/DevMenu.qml
@@ -42,6 +42,16 @@ Rectangle {
                     rootView.startRemoteJSDebugging()
                 }
             }
+            Button {
+                text: rootView.liveReload ? "Disable Live Reload" : "Enable Live Reload"
+                highlighted: true
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottomMargin: 10
+                onClicked: {
+                    devMenuRootId.state = "devMenuHidden"
+                    rootView.liveReload = !rootView.liveReload
+                }
+            }
         }
     }
 

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -101,10 +101,14 @@ public:
                 qCritical() << __PRETTY_FUNCTION__ << "Error monitoring change url";
                 return;
             }
+
+            if (!liveReload)
+                return;
+
             if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 205) {
                 bridge->reload();
             }
-            if (liveReload && bridge->ready()) {
+            if (bridge->ready()) {
                 monitorChangeUrl();
             }
         });


### PR DESCRIPTION
Once enabled, RootView listens to packager's URL which returns reply once some JS source is changed. Bridge reload happens then.