### PR TITLE
Added module to mock react-native-randombytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ moc_*.cpp
 
 /coverage
 /third-party
+CMakeFiles/
+CMakeLists.txt.user

--- a/ReactQt/runtime/src/3rdparty/rnrandombytes.cpp
+++ b/ReactQt/runtime/src/3rdparty/rnrandombytes.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2016, Canonical Ltd.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Author: Justin McPherson <justin.mcpherson@canonical.com>
+ *
+ */
+
+#include <memory>
+
+#include "bridge.h"
+#include "rnrandombytes.h"
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QMap>
+#include <QNetworkDiskCache>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QQuickImageProvider>
+
+class RNRandomBytesPrivate {
+
+public:
+    RNRandomBytesPrivate() {
+        qsrand(QDateTime::currentDateTime().currentMSecsSinceEpoch());
+        while (seed.size() < 4096) {
+            seed.append(QChar(qrand()));
+        }
+    }
+    QString seed;
+};
+
+RNRandomBytes::RNRandomBytes(QObject* parent) : QObject(parent), d_ptr(new RNRandomBytesPrivate) {}
+
+RNRandomBytes::~RNRandomBytes() {}
+
+QString RNRandomBytes::moduleName() {
+    return "RCTRNRandomBytes";
+}
+
+QList<ModuleMethod*> RNRandomBytes::methodsToExport() {
+    return QList<ModuleMethod*>{};
+}
+
+QVariantMap RNRandomBytes::constantsToExport() {
+    return QVariantMap{{"seed", d_ptr->seed}};
+}

--- a/ReactQt/runtime/src/3rdparty/rnrandombytes.h
+++ b/ReactQt/runtime/src/3rdparty/rnrandombytes.h
@@ -38,7 +38,6 @@ public:
     QList<ModuleMethod*> methodsToExport() override;
     QVariantMap constantsToExport() override;
 
-
 private:
     QScopedPointer<RNRandomBytesPrivate> d_ptr;
 };

--- a/ReactQt/runtime/src/3rdparty/rnrandombytes.h
+++ b/ReactQt/runtime/src/3rdparty/rnrandombytes.h
@@ -1,0 +1,46 @@
+
+/**
+ * Copyright (C) 2016, Canonical Ltd.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Author: Justin McPherson <justin.mcpherson@canonical.com>
+ *
+ */
+
+#ifndef RNRANDOMBYTES_H
+#define RNRANDOMBYTES_H
+
+#include <QUrl>
+
+#include "moduleinterface.h"
+
+class RNRandomBytesPrivate;
+class RNRandomBytes : public QObject, public ModuleInterface {
+    Q_OBJECT
+
+    Q_INTERFACES(ModuleInterface)
+
+    Q_DECLARE_PRIVATE(RNRandomBytes)
+
+public:
+    enum Event { Event_LoadStart, Event_Progress, Event_LoadError, Event_LoadSuccess, Event_LoadEnd };
+
+    typedef std::function<void(Event, const QVariantMap&)> LoadEventCallback;
+
+    RNRandomBytes(QObject* parent = 0);
+    ~RNRandomBytes();
+
+    QString moduleName() override;
+    QList<ModuleMethod*> methodsToExport() override;
+    QVariantMap constantsToExport() override;
+
+
+private:
+    QScopedPointer<RNRandomBytesPrivate> d_ptr;
+};
+
+#endif // RNRANDOMBYTES_H

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -62,6 +62,7 @@ set(
   componentmanagers/imagemanager.cpp
   componentmanagers/imageloader.cpp
   componentmanagers/pickermanager.cpp
+  3rdparty/rnrandombytes.cpp
   layout/flexbox.cpp
   utilities.cpp
   communication/serverconnection.cpp

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "bridge.h"
+#include "3rdparty/rnrandombytes.h"
 #include "appstate.h"
 #include "asynclocalstorage.h"
 #include "blobprovider.h"
@@ -99,6 +100,10 @@ public:
                            new SliderManager,
                            new ModalManager,
                            new PickerManager};
+    }
+
+    QObjectList thirdPartyModules() {
+        return QObjectList{new RNRandomBytes};
     }
 };
 
@@ -374,6 +379,7 @@ void Bridge::initModules() {
 
     QObjectList modules;
     modules << d->internalModules();
+    modules << d->thirdPartyModules();
 
     // Special cases // TODO:
     d->sourceCode = new SourceCode;

--- a/ReactQt/runtime/src/communication/serverconnection.h
+++ b/ReactQt/runtime/src/communication/serverconnection.h
@@ -46,7 +46,7 @@ public:
     void setLogErrors(bool logErrors);
 
 private:
-    virtual QIODevice* device();
+    virtual QIODevice* device() override;
 
 private:
     bool m_logErrors = true;
@@ -65,7 +65,7 @@ public:
     virtual bool isReady() override;
 
 private:
-    virtual QIODevice* device();
+    virtual QIODevice* device() override;
 
 private:
     QString m_serverHost = "127.0.0.1";

--- a/ReactQt/runtime/src/componentmanagers/navigatormanager.h
+++ b/ReactQt/runtime/src/componentmanagers/navigatormanager.h
@@ -43,8 +43,8 @@ private Q_SLOTS:
     void backTriggered();
 
 private:
-    virtual void configureView(QQuickItem* view) const;
-    virtual QString qmlComponentFile() const;
+    virtual void configureView(QQuickItem* view) const override;
+    virtual QString qmlComponentFile() const override;
 
     void invokeMethod(const QString& methodSignature, QQuickItem* item, const QVariantList& args = QVariantList{});
     QMetaMethod findMethod(const QString& methodSignature, QQuickItem* item);

--- a/ReactQt/runtime/src/componentmanagers/rawtextmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/rawtextmanager.h
@@ -39,8 +39,8 @@ public:
     bool shouldLayout() const override;
 
 protected:
-    virtual void configureView(QQuickItem* view) const;
-    virtual QString qmlComponentFile() const;
+    virtual void configureView(QQuickItem* view) const override;
+    virtual QString qmlComponentFile() const override;
 };
 
 #endif // RAWTEXTMANAGER_H

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -46,8 +46,8 @@ private Q_SLOTS:
 
 private:
     QVariantMap buildEventData(QQuickItem* item) const;
-    virtual void configureView(QQuickItem* view) const;
-    virtual QString qmlComponentFile() const;
+    virtual void configureView(QQuickItem* view) const override;
+    virtual QString qmlComponentFile() const override;
 };
 
 #endif // SCROLLVIEWMANAGER_H

--- a/ReactQt/runtime/src/componentmanagers/textmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.h
@@ -45,8 +45,8 @@ private:
     QQuickItem* parentTextItem(QQuickItem* textItem);
     bool propertyExplicitlySet(QQuickItem* item, const QString& propertyName);
 
-    virtual QString qmlComponentFile() const;
-    virtual void configureView(QQuickItem* view) const;
+    virtual QString qmlComponentFile() const override;
+    virtual void configureView(QQuickItem* view) const override;
 
 private:
     using StringSet = QSet<QString>;

--- a/ReactQt/runtime/src/reactitem.cpp
+++ b/ReactQt/runtime/src/reactitem.cpp
@@ -33,6 +33,8 @@ QString penStyleToBorderStyle(Qt::PenStyle penStyle) {
         return "dotted";
     case Qt::DashLine:
         return "dashed";
+    default:
+        return "solid";
     }
 }
 } // namespace
@@ -205,7 +207,7 @@ void ReactItem::setBorderRadius(double borderRadius) {
 }
 
 double ReactItem::borderTopLeftRadius() const {
-    d_func()->borderRadiuses[0];
+    return d_func()->borderRadiuses[0];
 }
 
 void ReactItem::setBorderTopLeftRadius(double borderTopLeftRadius) {
@@ -219,7 +221,7 @@ void ReactItem::setBorderTopLeftRadius(double borderTopLeftRadius) {
 }
 
 double ReactItem::borderTopRightRadius() const {
-    d_func()->borderRadiuses[1];
+    return d_func()->borderRadiuses[1];
 }
 
 void ReactItem::setBorderTopRightRadius(double borderTopRightRadius) {
@@ -233,7 +235,7 @@ void ReactItem::setBorderTopRightRadius(double borderTopRightRadius) {
 }
 
 double ReactItem::borderBottomLeftRadius() const {
-    d_func()->borderRadiuses[3];
+    return d_func()->borderRadiuses[3];
 }
 
 void ReactItem::setBorderBottomLeftRadius(double borderBottomLeftRadius) {
@@ -247,7 +249,7 @@ void ReactItem::setBorderBottomLeftRadius(double borderBottomLeftRadius) {
 }
 
 double ReactItem::borderBottomRightRadius() const {
-    d_func()->borderRadiuses[2];
+    return d_func()->borderRadiuses[2];
 }
 
 void ReactItem::setBorderBottomRightRadius(double borderBottomRightRadius) {


### PR DESCRIPTION
- Added RNRandomBytes module that mocks 3rd party library `react-native-randombytes`. 
- Fixed warnings (missed overrides, missed return statements)