### PR TITLE
workaround to fix TouchableOpacity

### DIFF
--- a/Examples/TouchableEvents/TouchableEventsApp.js
+++ b/Examples/TouchableEvents/TouchableEventsApp.js
@@ -15,7 +15,6 @@ export default class App extends Component<{}>  {
   };
 
   render() {
-    console.log("TouchableEventApp.js rerendered()")
     return (
       <View testID="touchable_feedback_events">
         <View style={[styles.row, {justifyContent: 'center'}]}>
@@ -45,7 +44,7 @@ export default class App extends Component<{}>  {
 
   _appendEvent = (eventName) => {
     var limit = 6;
-    var eventLog = this.state.eventLog.slice(0, limit - 1);
+    var eventLog = this.state.eventLog;
     eventLog.unshift(eventName);
     this.setState({eventLog});
   };

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -21,6 +21,7 @@ var PropTypes = require('prop-types');
 var TimerMixin = require('react-timer-mixin');
 var Touchable = require('Touchable');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+var Platform = require('Platform');
 
 var createReactClass = require('create-react-class');
 var ensurePositiveDelayProps = require('ensurePositiveDelayProps');
@@ -164,7 +165,7 @@ var TouchableOpacity = createReactClass({
       this.state.anim,
       {
         toValue: value,
-        duration: duration,
+        duration: (Platform.OS === 'desktop') ? 0 : duration,
         easing: Easing.inOut(Easing.quad),
         useNativeDriver: true,
       }


### PR DESCRIPTION
Text in `TouchableOpacity` control wasn't returning to opaque state after pressing. It is due to not implemented animation module on Qt side.
So far I suggest a quick fix which to fix behavior without implementing animation module.