### PR TITLE
Fixed incorrect argumets passing to JSTimers::callTimers

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -21,7 +21,6 @@ var PropTypes = require('prop-types');
 var TimerMixin = require('react-timer-mixin');
 var Touchable = require('Touchable');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-var Platform = require('Platform');
 
 var createReactClass = require('create-react-class');
 var ensurePositiveDelayProps = require('ensurePositiveDelayProps');
@@ -165,7 +164,7 @@ var TouchableOpacity = createReactClass({
       this.state.anim,
       {
         toValue: value,
-        duration: (Platform.OS === 'desktop') ? 0 : duration,
+        duration: duration,
         easing: Easing.inOut(Easing.quad),
         useNativeDriver: true,
       }

--- a/RNTester/js/RNTesterApp.desktop.js
+++ b/RNTester/js/RNTesterApp.desktop.js
@@ -65,9 +65,9 @@ class RNTesterApp extends React.Component {
   }
 
   componentDidMount() {
-    let action = RNTesterActions.ExampleAction('TextExample');
+    let action = RNTesterActions.ExampleAction('TouchableExample');
     const newState = RNTesterNavigationReducer({
-      openExample: 'TextExample',
+      openExample: 'TouchableExample',
     }, action);
     this.setState(
       newState,

--- a/ReactQt/runtime/src/timing.h
+++ b/ReactQt/runtime/src/timing.h
@@ -46,6 +46,9 @@ public:
     QVariantMap constantsToExport() override;
 
 private:
+    void callTimer(const int timerId);
+
+private:
     QPointer<Bridge> m_bridge;
     QMap<int, QTimer*> m_activeTimers;
 };


### PR DESCRIPTION
- Fixed mistake with sending arguments to JSTimers::callTimers. 
- Reverted changes in `TouchableOpacity` to enable timers usage

Now TouchableOpacity and TouchableHighlight works correctly. Also `onLongPress` functionality fixed in touchables.