### PR TITLE
Resolve 3rd party managers modules registering issue

### DIFF
--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -27,6 +27,7 @@ class ImageLoader;
 class EventDispatcher;
 class RedboxItem;
 class TestModule;
+class ModuleInterface;
 
 class BridgePrivate;
 class Bridge : public QObject {
@@ -117,6 +118,7 @@ private:
     void setupExecutor();
     void setJsAppStarted(bool started);
     void invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args);
+    void addModuleData(QObject* module);
 
     QScopedPointer<BridgePrivate> d_ptr;
 };


### PR DESCRIPTION
UIManager exports to JS the info of all others view managers. This happens in setBridge method of UIManager. Because of above, UIManager should be "initialized" after all others modules.

Source code is refactored to achieve above (previously, external modules were instantiated after UIManager and were not found at JS side) .