### PR TITLE
Extend TextInput with support of missed props

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -416,7 +416,6 @@ const TextInput = createReactClass({
      * where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and
      * the typed-in character otherwise including `' '` for space.
      * Fires before `onChange` callbacks.
-     * @platform ios
      */
     onKeyPress: PropTypes.func,
     /**

--- a/RNTester/js/RNTesterApp.desktop.js
+++ b/RNTester/js/RNTesterApp.desktop.js
@@ -65,9 +65,9 @@ class RNTesterApp extends React.Component {
   }
 
   componentDidMount() {
-    let action = RNTesterActions.ExampleAction('WebViewExample');
+    let action = RNTesterActions.ExampleAction('TextInputExample');
     const newState = RNTesterNavigationReducer({
-      openExample: 'WebViewExample',
+      openExample: 'TextInputExample',
     }, action);
     this.setState(
       newState,

--- a/RNTester/js/TextInputExample.desktop.js
+++ b/RNTester/js/TextInputExample.desktop.js
@@ -23,6 +23,7 @@ class TextEventsExample extends React.Component {
     curText: '<No Event>',
     prevText: '<No Event>',
     prev2Text: '<No Event>',
+    prev3Text: '<No Event>',
   };
 
   updateText = (text) => {
@@ -31,13 +32,14 @@ class TextEventsExample extends React.Component {
         curText: text,
         prevText: state.curText,
         prev2Text: state.prevText,
+        prev3Text: state.prev2Text,
       };
     });
   };
 
   render() {
     return (
-      <View>
+      <View height="110">
         <TextInput
           autoCapitalize="none"
           placeholder="Enter text to see events"
@@ -57,12 +59,21 @@ class TextEventsExample extends React.Component {
           onSubmitEditing={(event) => this.updateText(
             'onSubmitEditing text: ' + event.nativeEvent.text
           )}
+          onSelectionChange={(event) => this.updateText(
+            'onSelectionChange range: ' +
+              event.nativeEvent.selection.start + ',' +
+              event.nativeEvent.selection.end
+          )}
+          onKeyPress={(event) => {
+            this.updateText('onKeyPress key: ' + event.nativeEvent.key);
+          }}
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>
           {this.state.curText}{'\n'}
           (prev: {this.state.prevText}){'\n'}
-          (prev2: {this.state.prev2Text})
+          (prev2: {this.state.prev2Text}){'\n'}
+          (prev3: {this.state.prev3Text})
         </Text>
       </View>
     );

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.h
@@ -33,10 +33,16 @@ public:
 public slots:
     void sendTextEditedToJs(QQuickItem* textInput);
     void sendSelectionChangeToJs(QQuickItem* textInput);
+    void sendOnSubmitEditingToJs(QQuickItem* textInput);
+    void sendOnEndEditingToJs(QQuickItem* textInput);
+    void sendOnFocusToJs(QQuickItem* textInput);
+    void sendOnKeyPressToJs(QQuickItem* textInput, QString keyText);
 
 private:
     virtual QString qmlComponentFile() const override;
     virtual void configureView(QQuickItem* view) const override;
+
+    void sendTextInputEvent(QQuickItem* textInput, QString eventName, QVariantMap additionalEventData = QVariantMap());
 
 private:
     QScopedPointer<TextInputManagerPrivate> d_ptr;

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -29,5 +29,17 @@ TextArea {
     onSelectionEndChanged: {
         parent.textInputManager.sendSelectionChangeToJs(textField)
     }
+    onEditingFinished: {
+        textInputManager.sendOnSubmitEditingToJs(textField)
+        textInputManager.sendOnEndEditingToJs(textField)
+    }
+    onFocusChanged: {
+        if (focus) {
+            textInputManager.sendOnFocusToJs(textField)
+        }
+    }
+    Keys.onPressed: {
+        textInputManager.sendOnKeyPressToJs(textField, event.text)
+    }
 }
 

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -29,4 +29,19 @@ TextField {
     onSelectionEndChanged: {
         textInputManager.sendSelectionChangeToJs(textField)
     }
+    onAccepted: {
+        textInputManager.sendOnSubmitEditingToJs(textField)
+    }
+    onEditingFinished: {
+        textInputManager.sendOnEndEditingToJs(textField)
+    }
+    onFocusChanged: {
+        if (focus) {
+            textInputManager.sendOnFocusToJs(textField)
+        }
+    }
+    Keys.onPressed: {
+        textInputManager.sendOnKeyPressToJs(textField, event.text)
+    }
+
 }


### PR DESCRIPTION
TextInput extended to support following props:

- onSubmitEditing
- onEndEditing
- onFocus
- onBlur
- onKeyPress

RnTester event handling JS test updated to JS test code from RN v.0.51