### PR TITLE
NetInfo isConnected is not get fired

### DIFF
--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -79,7 +79,7 @@ if (Platform.OS === 'ios') {
     return connectionType !== 'NONE' && connectionType !== 'UNKNOWN';
   };
 } else if (Platform.OS === 'desktop') {
-  _isConnected = function(
+  _isConnectedDeprecated = function(
     networkAccessibility: NetworkAccessibility
   ): bool {
     return networkAccessibility === 'Accessible';
@@ -87,7 +87,11 @@ if (Platform.OS === 'ios') {
 }
 
 function _isConnected(connection) {
-  return connection.type !== 'none' && connection.type !== 'unknown';
+  if (Platform.OS === 'desktop') {
+    return connection.networkAccessibility === 'Accessible';
+  } else {
+    return connection.type !== 'none' && connection.type !== 'unknown';
+  }
 }
 
 const _isConnectedSubscriptions = new Map();
@@ -290,6 +294,7 @@ const NetInfo = {
       return {
         type: resp.connectionType,
         effectiveType: resp.effectiveConnectionType,
+        networkAccessibility: resp.network_info
       };
     });
   },

--- a/RNTester/js/RNTesterApp.desktop.js
+++ b/RNTester/js/RNTesterApp.desktop.js
@@ -65,9 +65,9 @@ class RNTesterApp extends React.Component {
   }
 
   componentDidMount() {
-    let action = RNTesterActions.ExampleAction('TextInputExample');
+    let action = RNTesterActions.ExampleAction('ViewExample');
     const newState = RNTesterNavigationReducer({
-      openExample: 'TextInputExample',
+      openExample: 'ViewExample',
     }, action);
     this.setState(
       newState,

--- a/RNTester/js/RNTesterList.desktop.js
+++ b/RNTester/js/RNTesterList.desktop.js
@@ -60,6 +60,10 @@ const ComponentExamples: Array<RNTesterExample> = [
   {
     key: 'WebViewExample',
     module: require('./WebViewExample'),
+  },
+  {
+    key: 'ViewExample',
+    module: require('./ViewExample'),
   }
 ];
 

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -187,18 +187,11 @@ void Bridge::enqueueJSCall(const QString& module, const QString& method, const Q
 }
 
 void Bridge::invokePromiseCallback(double callbackCode, const QVariantList& args) {
-    invokePromiseViaExecutor(QVariantList{callbackCode, args});
-}
-
-void Bridge::invokePromiseCallback(double callbackCode, const QVariantMap& args) {
-    invokePromiseViaExecutor(QVariantList{callbackCode, args});
-}
-
-void Bridge::invokePromiseViaExecutor(const QVariantList& args) {
     if (!d_func()->executor)
         return;
-    d_func()->executor->executeJSCall(
-        "invokeCallbackAndReturnFlushedQueue", args, [=](const QJsonDocument& doc) { processResult(doc); });
+    d_func()->executor->executeJSCall("invokeCallbackAndReturnFlushedQueue",
+                                      QVariantList{callbackCode, args},
+                                      [=](const QJsonDocument& doc) { processResult(doc); });
 }
 
 void Bridge::invokeAndProcess(const QString& method, const QVariantList& args) {

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -57,7 +57,6 @@ public:
     void loadBundle(const QUrl& bundleUrl);
 
     void invokePromiseCallback(double callbackCode, const QVariantList& args);
-    void invokePromiseCallback(double callbackCode, const QVariantMap& args);
     void enqueueJSCall(const QString& module, const QString& method, const QVariantList& args);
     void invokeAndProcess(const QString& method, const QVariantList& args);
     void executeSourceCode(const QByteArray& sourceCode);
@@ -120,7 +119,6 @@ private:
     void setJsAppStarted(bool started);
     void invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args);
     void addModuleData(QObject* module);
-    void invokePromiseViaExecutor(const QVariantList& args);
 
     QScopedPointer<BridgePrivate> d_ptr;
 };

--- a/ReactQt/runtime/src/qml/ReactView.qml
+++ b/ReactQt/runtime/src/qml/ReactView.qml
@@ -7,9 +7,12 @@ React.Item {
     property var p_transformMatrix;
     property var viewManager: null
     property string p_nativeID
+    property int p_zIndex: 0
     property var flexbox: React.Flexbox {control: viewRoot}
 
     objectName: p_nativeID
 
-    onP_transformMatrixChanged: viewManager.manageTransforMatrix(p_transformMatrix, viewRoot)
+    onP_transformMatrixChanged: viewManager.manageTransformMatrix(p_transformMatrix, viewRoot)
+
+    z: p_zIndex
 }


### PR DESCRIPTION
- NetInfo modified to fire isConnected even for desktop platform
-  Reverted back Bridge::invokePromiseCallback since `invokeCallbackAndReturnFlushedQueue(cbID: number, args: Array<any>)` expects QVariantList only as second argument.

----
- zIndex prop support by View (at least zIndex sample from RnTester's ViewExample.js works fine)
  