### PR TITLE
refs #192 - Use LocalServerConnection by default

### DIFF
--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -19,9 +19,18 @@ find_package(Qt5WebSockets REQUIRED)
 # Format EXTERNAL_MODULES to contain array of external modules type names defined as strings
 string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}")
 
+if (JS_BUNDLE_PATH)
+  set(JS_BUNDLE_RESOURCE "<file alias=\"index.desktop.bundle\">${JS_BUNDLE_PATH}</file>")
+endif()
+
 configure_file(
   main.qml.in
   ${CMAKE_CURRENT_SOURCE_DIR}/main.qml
+)
+
+configure_file(
+  main.qrc.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/main.qrc
 )
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../runtime/src)

--- a/ReactQt/application/src/main.cpp
+++ b/ReactQt/application/src/main.cpp
@@ -114,12 +114,14 @@ private:
     QString m_packagerTemplate = "http://%1:%2/index.desktop.bundle?platform=desktop&dev=true";
     QUrl m_codeLocation;
     QString m_pluginsPath;
-    QString m_executor = "NetExecutor";
+    QString m_executor = "LocalServerConnection";
 };
 
 int main(int argc, char** argv) {
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
     Q_INIT_RESOURCE(react_resources);
+
     QQuickView view;
     ReactNativeProperties* rnp = new ReactNativeProperties(&view);
 

--- a/ReactQt/application/src/main.qrc.in
+++ b/ReactQt/application/src/main.qrc.in
@@ -1,0 +1,16 @@
+
+<!--
+  Copyright (C) 2016, Canonical Ltd.
+  All rights reserved.
+
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree. An additional grant
+  of patent rights can be found in the PATENTS file in the same directory.
+-->
+
+<RCC>
+  <qresource>
+    <file>main.qml</file>
+    ${JS_BUNDLE_RESOURCE}
+  </qresource>
+</RCC>

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -135,12 +135,12 @@ void Bridge::setupExecutor() {
 
     if (!d->executor) {
         ServerConnection* conn =
-            qobject_cast<ServerConnection*>(utilities::createQObjectInstance(d->serverConnectionType + "*"));
+            qobject_cast<ServerConnection*>(utilities::createQObjectInstance(d->serverConnectionType));
 
         if (conn == nullptr) {
             qWarning() << __PRETTY_FUNCTION__ << "Could not construct connection: " << d->serverConnectionType
-                       << "constructing default (RemoteServerConnection)";
-            conn = new RemoteServerConnection();
+                       << "constructing default (LocalServerConnection)";
+            conn = new LocalServerConnection();
         }
 
         d->executor = new Executor(conn, this);

--- a/local-cli/desktop/runDesktop.js
+++ b/local-cli/desktop/runDesktop.js
@@ -71,8 +71,11 @@ function actuallyRun(args, reject) {
         appArgs.push('--host=' + args['host']);
       if (args['port'])
         appArgs.push('--port=' + args['port']);
-      if (args['executor'])
+      if (args['executor']) {
         appArgs.push('--executor=' + args['executor']);
+      } else {
+        appArgs.push('--executor=RemoteServerConnection');
+      }
       if (args['arch'].startsWith('arm'))
         appArgs.push('--on-device');
       appArgs.push('--plugins-path=' + args['plugins-path']);

--- a/local-cli/generator-desktop/templates/build.sh
+++ b/local-cli/generator-desktop/templates/build.sh
@@ -9,14 +9,21 @@
 
 # XXX: Don't move this script
 cd $(dirname $0)
-externalModulesPaths="$1"
+for i in "$@"
+do
+case $i in
+  -e=*|--externalModulesPaths=*)
+  ExternalModulesPaths="${i#*=}" ;;
+  -j=*|--jsBundlePath=*)
+  JsBundlePath="${i#*=}" ;;
+esac
+done
 
-echo $externalModulesPaths
+echo "build.sh external modules paths: "$ExternalModulesPaths
+echo "build.sh JS bundle path: "$JsBundlePath
 
 # Workaround
 rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile
 
 # Build project
-cmake -DCMAKE_BUILD_TYPE=Debug -DEXTERNAL_MODULES_DIR="$externalModulesPaths" . && make && cp ./bin/<%= name %> click/
-
-
+cmake -DCMAKE_BUILD_TYPE=Debug -DEXTERNAL_MODULES_DIR="$ExternalModulesPaths" -DJS_BUNDLE_PATH="$JsBundlePath" . && make && cp ./bin/TestProject10 click/

--- a/local-cli/generator-desktop/templates/ubuntu-server.js
+++ b/local-cli/generator-desktop/templates/ubuntu-server.js
@@ -10,6 +10,11 @@
  *
  */
 
+if (process.argv.indexOf('--pipe') != -1) {
+  console.log = console.error
+  console.info = console.error
+}
+
 var net = require('net');
 var repl = require('repl');
 var vm = require('vm');
@@ -110,7 +115,6 @@ function rnUbuntuServer(readable, writable) {
 }
 
 if (process.argv.indexOf('--pipe') != -1) {
-  console.log = console.error
   rnUbuntuServer(process.stdin, process.stdout);
 } else {
   var server = net.createServer((sock) => {

--- a/ubuntu-server.js
+++ b/ubuntu-server.js
@@ -10,6 +10,11 @@
  *
  */
 
+if (process.argv.indexOf('--pipe') != -1) {
+  console.log = console.error
+  console.info = console.error
+}
+
 var net = require('net');
 var repl = require('repl');
 var vm = require('vm');
@@ -110,7 +115,6 @@ function rnUbuntuServer(readable, writable) {
 }
 
 if (process.argv.indexOf('--pipe') != -1) {
-  console.log = console.error
   rnUbuntuServer(process.stdin, process.stdout);
 } else {
   var server = net.createServer((sock) => {


### PR DESCRIPTION
- LocalServerConnection (pipe for node process) is used by default
- `react-native run-desktop` updated to use `RemoteServerConnection` by default, if anything else is not specified
- Redirect console.info to console.error stream if process pipe is used for JS server
- Enable high dpi displays support for users apps by setting  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

------

package.json of custom app is extended with support of "desktopJSBundlePath" property to put path to JS bundle which will be embedded into final binary as resource and loaded from there (instead of querying rn-packager)