### PR TITLE
Define text property for ReactTextInputArea root QML item

### DIFF
--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -7,11 +7,13 @@ import  "../js/utils.js" as Utils
 Flickable {
     id: textField
     property var textInputRoot: parent
+    property alias text: textArea.text
     anchors.fill: textInputRoot
     ScrollBar.vertical: ScrollBar {}
 
     TextArea.flickable: TextArea {
 
+        id: textArea
         text: textInputRoot.p_text
         color: textInputRoot.p_color
         placeholderText: textInputRoot.p_placeholderText


### PR DESCRIPTION
`TextInputManager` [expects](https://github.com/status-im/react-native-desktop/blob/react-native-qt/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp#L104) `text` property to be defined to fetch actual text from it.