### PR TITLE
refs #210 - Optimizes onSelectionChange event generation; Disables it…

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -70,8 +70,11 @@ void TextInputManager::sendSelectionChangeToJs(QQuickItem* textInput) {
     int start = textInput->property("selectionStart").toInt();
     int end = textInput->property("selectionEnd").toInt();
 
-    sendTextInputEvent(
-        textInput, EVENT_ON_SELECTION_CHANGE, QVariantMap{{"selection", QVariantMap{{"start", start}, {"end", end}}}});
+    // TODO: Generation of onSelectionChange event causes issue
+    // https://github.com/status-im/react-native-desktop/issues/210
+    // sendTextInputEvent(
+    //    textInput, EVENT_ON_SELECTION_CHANGE, QVariantMap{{"selection", QVariantMap{{"start", start}, {"end",
+    //    end}}}});
 }
 
 void TextInputManager::sendOnSubmitEditingToJs(QQuickItem* textInput) {

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -32,8 +32,7 @@ Flickable {
         }
 
         onTextChanged: textInputRoot.textInputManager.sendTextEditedToJs(textField)
-        onSelectionStartChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
-        onSelectionEndChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
+        onCursorPositionChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
         Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField, event.text)
         onContentSizeChanged: {
             if(textInputManager)

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -26,8 +26,7 @@ TextField {
     }
 
     onTextChanged:              textInputManager.sendTextEditedToJs(textField)
-    onSelectionStartChanged:    textInputManager.sendSelectionChangeToJs(textField)
-    onSelectionEndChanged:      textInputManager.sendSelectionChangeToJs(textField)
+    onCursorPositionChanged:    textInputManager.sendSelectionChangeToJs(textField)
     onAccepted:                 textInputManager.sendOnSubmitEditingToJs(textField)
     onEditingFinished:          textInputManager.sendOnEndEditingToJs(textField)
     onContentSizeChanged:       {


### PR DESCRIPTION
@vkjr was not able to find out why onSelectionChange event has such negative impact on finding correct responder of next generated event. Changelist disables generation of onSelectionChange event for text-input component and also does optimization to not generate such events twice from QML.