### PR TITLE
Optional JavaScriptCore JS engine support #215

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,16 @@ project(react-native-desktop)
 set(PROJECT_NAME "react-native-desktop")
 set(PROJECT_VERSION "0.0.1")
 
+option(JAVASCRIPTCORE_ENABLED
+    "Build with JavaScriptCore enabled"
+    OFF)
+
+if(JAVASCRIPTCORE_ENABLED)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 if(WIN32)
   set(REACT_BUILD_STATIC_LIB 1)
   set(USE_QTWEBKIT 1)

--- a/ReactCommon/cxxreact/JSCExecutor.cpp
+++ b/ReactCommon/cxxreact/JSCExecutor.cpp
@@ -1,5 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
-
+// clang-format off
 #include "JSCExecutor.h"
 
 #include <algorithm>
@@ -226,8 +226,8 @@ namespace facebook {
       installNativeHook<&JSCExecutor::nativeFlushQueueImmediate>("nativeFlushQueueImmediate");
       installNativeHook<&JSCExecutor::nativeCallSyncHook>("nativeCallSyncHook");
 
-      installGlobalFunction(m_context, "nativeLoggingHook", JSCNativeHooks::loggingHook);
-      installGlobalFunction(m_context, "nativePerformanceNow", JSCNativeHooks::nowHook);
+      //installGlobalFunction(m_context, "nativeLoggingHook", JSCNativeHooks::loggingHook);
+      //installGlobalFunction(m_context, "nativePerformanceNow", JSCNativeHooks::nowHook);
 
 #if DEBUG
       installGlobalFunction(m_context, "nativeInjectHMRUpdate", nativeInjectHMRUpdate);
@@ -238,7 +238,7 @@ namespace facebook {
       addJSCMemoryHooks(m_context);
       addJSCPerfStatsHooks(m_context);
 
-      JSCNativeHooks::installPerfHooks(m_context);
+      //JSCNativeHooks::installPerfHooks(m_context);
 
       if (canUseSamplingProfiler(m_context)) {
         initSamplingProfilerOnMainJSCThread(m_context);
@@ -380,7 +380,7 @@ namespace facebook {
                         "sourceURL", sourceURL);
 
       std::string scriptName = simpleBasename(sourceURL);
-      ReactMarker::logTaggedMarker(ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
+      // ReactMarker::logTaggedMarker(ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
       String jsSourceURL(m_context, sourceURL.c_str());
 
       // TODO t15069155: reduce the number of overrides here
@@ -434,9 +434,9 @@ namespace facebook {
         JSContextLock lock(m_context);
         {
           SystraceSection s_("JSCExecutor::loadApplicationScript-createExpectingAscii");
-          ReactMarker::logMarker(ReactMarker::JS_BUNDLE_STRING_CONVERT_START);
+          // ReactMarker::logMarker(ReactMarker::JS_BUNDLE_STRING_CONVERT_START);
           jsScript = adoptString(std::move(script));
-          ReactMarker::logMarker(ReactMarker::JS_BUNDLE_STRING_CONVERT_STOP);
+          // ReactMarker::logMarker(ReactMarker::JS_BUNDLE_STRING_CONVERT_STOP);
         }
 
         SystraceSection s_("JSCExecutor::loadApplicationScript-evaluateScript");
@@ -446,7 +446,7 @@ namespace facebook {
       flush();
 
       ReactMarker::logMarker(ReactMarker::CREATE_REACT_CONTEXT_STOP);
-      ReactMarker::logTaggedMarker(ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
+      // ReactMarker::logTaggedMarker(ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
     }
 
     void JSCExecutor::setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) {

--- a/ReactCommon/cxxreact/JSCNativeModules.cpp
+++ b/ReactCommon/cxxreact/JSCNativeModules.cpp
@@ -1,4 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
+// clang-format off
 
 #include "JSCNativeModules.h"
 
@@ -43,7 +44,7 @@ void JSCNativeModules::reset() {
 }
 
 folly::Optional<Object> JSCNativeModules::createModule(const std::string& name, JSContextRef context) {
-  ReactMarker::logTaggedMarker(ReactMarker::NATIVE_MODULE_SETUP_START, name.c_str());
+  //ReactMarker::logTaggedMarker(ReactMarker::NATIVE_MODULE_SETUP_START, name.c_str());
 
   if (!m_genNativeModuleJS) {
     auto global = Object::getGlobalObject(context);
@@ -64,7 +65,7 @@ folly::Optional<Object> JSCNativeModules::createModule(const std::string& name, 
 
   folly::Optional<Object> module(moduleInfo.asObject().getProperty("module").asObject());
 
-  ReactMarker::logTaggedMarker(ReactMarker::NATIVE_MODULE_SETUP_STOP, name.c_str());
+  //ReactMarker::logTaggedMarker(ReactMarker::NATIVE_MODULE_SETUP_STOP, name.c_str());
 
   return module;
 }

--- a/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/ReactCommon/cxxreact/ModuleRegistry.h
@@ -1,5 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
-
+// clang-format off
 #pragma once
 
 #include <memory>
@@ -9,6 +9,10 @@
 #include <cxxreact/JSExecutor.h>
 #include <folly/Optional.h>
 #include <folly/dynamic.h>
+
+#include <QList>
+
+class ModuleData;
 
 #ifndef RN_EXPORT
 #define RN_EXPORT __attribute__((visibility("default")))
@@ -38,6 +42,8 @@ class RN_EXPORT ModuleRegistry {
   ModuleRegistry(std::vector<std::unique_ptr<NativeModule>> modules, ModuleNotFoundCallback callback = nullptr);
   void registerModules(std::vector<std::unique_ptr<NativeModule>> modules);
 
+  void registerModules(QList<ModuleData*> modules);
+
   std::vector<std::string> moduleNames();
 
   folly::Optional<ModuleConfig> getConfig(const std::string& name);
@@ -48,6 +54,8 @@ class RN_EXPORT ModuleRegistry {
  private:
   // This is always populated
   std::vector<std::unique_ptr<NativeModule>> modules_;
+
+  std::vector<ModuleData*> qtModules_;
 
   // This is used to extend the population of modulesByName_ if registerModules is called after moduleNames
   void updateModuleNamesFromIndex(size_t size);
@@ -63,6 +71,8 @@ class RN_EXPORT ModuleRegistry {
   // If the function returns true, ModuleRegistry will try to find the module again (assuming it's registered)
   // If the functon returns false, ModuleRegistry will not try to find the module and return nullptr instead.
   ModuleNotFoundCallback moduleNotFoundCallback_;
+
+  bool qtModulesUsed_ = true;
 };
 
 }

--- a/ReactCommon/cxxreact/Platform.cpp
+++ b/ReactCommon/cxxreact/Platform.cpp
@@ -1,4 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
+// clang-format off
 
 #include "Platform.h"
 
@@ -14,7 +15,7 @@ namespace ReactMarker {
 
 LogTaggedMarker logTaggedMarker = nullptr;
 void logMarker(const ReactMarkerId markerId) {
-  logTaggedMarker(markerId, nullptr);
+  //logTaggedMarker(markerId, nullptr);
 }
 
 }

--- a/ReactCommon/jschelpers/JSCWrapper.h
+++ b/ReactCommon/jschelpers/JSCWrapper.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-
+// clang-format off
 #pragma once
 
 #include <functional>
@@ -57,10 +57,8 @@ JSC_IMPORT void FBJSContextStartGCTimers(JSContextRef);
 }
 #endif
 
-#if defined(__APPLE__)
-#import <objc/objc.h>
-#import <JavaScriptCore/JSStringRefCF.h>
-#import <string>
+#include <JavaScriptCore/JSStringRef.h>
+#include <string>
 
 /**
  * JSNoBytecodeFileFormatVersion
@@ -72,7 +70,7 @@ RN_EXPORT extern const int32_t JSNoBytecodeFileFormatVersion;
 namespace facebook {
 namespace react {
 
-#define JSC_WRAPPER_METHOD(m) decltype(&m) m
+#define JSC_WRAPPER_METHOD(m) decltype(&m) m##_
 
 struct JSCWrapper {
   // JSGlobalContext
@@ -91,11 +89,11 @@ struct JSCWrapper {
 
   // JSString
   JSC_WRAPPER_METHOD(JSStringCreateWithUTF8CString);
-  JSC_WRAPPER_METHOD(JSStringCreateWithCFString);
+  //JSC_WRAPPER_METHOD(JSStringCreateWithCFString);
   #if WITH_FBJSCEXTENSIONS
   JSC_WRAPPER_METHOD(JSStringCreateWithUTF8CStringExpectAscii);
   #endif
-  JSC_WRAPPER_METHOD(JSStringCopyCFString);
+  //JSC_WRAPPER_METHOD(JSStringCopyCFString);
   JSC_WRAPPER_METHOD(JSStringGetCharactersPtr);
   JSC_WRAPPER_METHOD(JSStringGetLength);
   JSC_WRAPPER_METHOD(JSStringGetMaximumUTF8CStringSize);
@@ -157,8 +155,8 @@ struct JSCWrapper {
   JSC_WRAPPER_METHOD(configureJSCForIOS);
 
   // Objective-C API
-  Class JSContext;
-  Class JSValue;
+  //Class JSContext;
+  //Class JSValue;
 
   int32_t JSBytecodeFileFormatVersion;
 };
@@ -176,9 +174,7 @@ RN_EXPORT const JSCWrapper *systemJSCWrapper();
 RN_EXPORT const JSCWrapper *customJSCWrapper();
 
 } }
-
-#else
-
+/*
 namespace facebook {
 namespace react {
 
@@ -189,5 +185,4 @@ bool isCustomJSCPtr(T *x) {
 }
 
 } }
-
-#endif
+*/

--- a/ReactCommon/jschelpers/systemJSCWrapper.cpp
+++ b/ReactCommon/jschelpers/systemJSCWrapper.cpp
@@ -6,21 +6,15 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-
+// clang-format off
 #include <jschelpers/JSCWrapper.h>
 
-#if defined(__APPLE__)
-
 #include <mutex>
-
-#include <objc/runtime.h>
 
 // Crash the app (with a descriptive stack trace) if a function that is not supported by
 // the system JSC is called.
 #define UNIMPLEMENTED_SYSTEM_JSC_FUNCTION(FUNC_NAME)            \
-static void Unimplemented_##FUNC_NAME(__unused void* args...) { \
-  assert(false);                                                \
-}
+static void Unimplemented_##FUNC_NAME(void* args...) {}
 
 UNIMPLEMENTED_SYSTEM_JSC_FUNCTION(JSEvaluateBytecodeBundle)
 #if WITH_FBJSCEXTENSIONS
@@ -42,6 +36,21 @@ bool JSSamplingProfilerEnabled() {
 
 const int32_t JSNoBytecodeFileFormatVersion = -1;
 
+void JSGlobalContextEnableDebugger(
+  JSGlobalContextRef ctx, facebook::react::IInspector &globalInspector,
+   const char *title, const std::function<bool()> &checkIsInspectedRemote) {}
+void JSGlobalContextDisableDebugger(
+  JSGlobalContextRef ctx, facebook::react::IInspector &globalInspector) {}
+
+// This is used to substitute an alternate JSC implementation for
+// testing. These calls must all be ABI compatible with the standard JSC.
+JSValueRef JSEvaluateBytecodeBundle(JSContextRef, JSObjectRef, int, JSStringRef,
+                                    JSValueRef *) {
+  return JSValueRef();
+}
+void JSStartSamplingProfilingOnMainJSCThread(JSGlobalContextRef) {}
+JSValueRef JSPokeSamplingProfiler(JSContextRef) { return JSValueRef(); }
+
 namespace facebook {
 namespace react {
 
@@ -53,95 +62,95 @@ const JSCWrapper* systemJSCWrapper() {
   static std::once_flag flag;
   std::call_once(flag, []() {
     s_systemWrapper = {
-      .JSGlobalContextCreateInGroup = JSGlobalContextCreateInGroup,
-      .JSGlobalContextRelease = JSGlobalContextRelease,
-      .JSGlobalContextSetName = JSGlobalContextSetName,
+      .JSGlobalContextCreateInGroup_ = JSGlobalContextCreateInGroup,
+      .JSGlobalContextRelease_ = JSGlobalContextRelease,
+      .JSGlobalContextSetName_ = JSGlobalContextSetName,
 
-      .JSContextGetGlobalContext = JSContextGetGlobalContext,
-      .JSContextGetGlobalObject = JSContextGetGlobalObject,
-      .FBJSContextStartGCTimers =
+      .JSContextGetGlobalContext_ = JSContextGetGlobalContext,
+      .JSContextGetGlobalObject_ = JSContextGetGlobalObject,
+      .FBJSContextStartGCTimers_ =
         (decltype(&FBJSContextStartGCTimers))
         Unimplemented_FBJSContextStartGCTimers,
 
-      .JSEvaluateScript = JSEvaluateScript,
-      .JSEvaluateBytecodeBundle =
+      .JSEvaluateScript_ = JSEvaluateScript,
+      .JSEvaluateBytecodeBundle_ =
         (decltype(&JSEvaluateBytecodeBundle))
         Unimplemented_JSEvaluateBytecodeBundle,
 
-      .JSStringCreateWithUTF8CString = JSStringCreateWithUTF8CString,
-      .JSStringCreateWithCFString = JSStringCreateWithCFString,
+      .JSStringCreateWithUTF8CString_ = JSStringCreateWithUTF8CString,
+      //.JSStringCreateWithCFString_ = JSStringCreateWithCFString,
       #if WITH_FBJSCEXTENSIONS
       .JSStringCreateWithUTF8CStringExpectAscii =
         (decltype(&JSStringCreateWithUTF8CStringExpectAscii))
         Unimplemented_JSStringCreateWithUTF8CStringExpectAscii,
       #endif
-      .JSStringCopyCFString = JSStringCopyCFString,
-      .JSStringGetCharactersPtr = JSStringGetCharactersPtr,
-      .JSStringGetLength = JSStringGetLength,
-      .JSStringGetMaximumUTF8CStringSize = JSStringGetMaximumUTF8CStringSize,
-      .JSStringIsEqualToUTF8CString = JSStringIsEqualToUTF8CString,
-      .JSStringRelease = JSStringRelease,
-      .JSStringRetain = JSStringRetain,
+      //.JSStringCopyCFString_ = JSStringCopyCFString,
+      .JSStringGetCharactersPtr_ = JSStringGetCharactersPtr,
+      .JSStringGetLength_ = JSStringGetLength,
+      .JSStringGetMaximumUTF8CStringSize_ = JSStringGetMaximumUTF8CStringSize,
+      .JSStringIsEqualToUTF8CString_ = JSStringIsEqualToUTF8CString,
+      .JSStringRelease_ = JSStringRelease,
+      .JSStringRetain_ = JSStringRetain,
 
-      .JSClassCreate = JSClassCreate,
-      .JSClassRelease = JSClassRelease,
+      .JSClassCreate_ = JSClassCreate,
+      .JSClassRelease_ = JSClassRelease,
 
-      .JSObjectCallAsConstructor = JSObjectCallAsConstructor,
-      .JSObjectCallAsFunction = JSObjectCallAsFunction,
-      .JSObjectGetPrivate = JSObjectGetPrivate,
-      .JSObjectGetProperty = JSObjectGetProperty,
-      .JSObjectGetPropertyAtIndex = JSObjectGetPropertyAtIndex,
-      .JSObjectIsConstructor = JSObjectIsConstructor,
-      .JSObjectIsFunction = JSObjectIsFunction,
-      .JSObjectMake = JSObjectMake,
-      .JSObjectMakeArray = JSObjectMakeArray,
-      .JSObjectMakeDate = JSObjectMakeDate,
-      .JSObjectMakeError = JSObjectMakeError,
-      .JSObjectMakeFunctionWithCallback = JSObjectMakeFunctionWithCallback,
-      .JSObjectSetPrivate = JSObjectSetPrivate,
-      .JSObjectSetProperty = JSObjectSetProperty,
-      .JSObjectSetPropertyAtIndex = JSObjectSetPropertyAtIndex,
+      .JSObjectCallAsConstructor_ = JSObjectCallAsConstructor,
+      .JSObjectCallAsFunction_ = JSObjectCallAsFunction,
+      .JSObjectGetPrivate_ = JSObjectGetPrivate,
+      .JSObjectGetProperty_ = JSObjectGetProperty,
+      .JSObjectGetPropertyAtIndex_ = JSObjectGetPropertyAtIndex,
+      .JSObjectIsConstructor_ = JSObjectIsConstructor,
+      .JSObjectIsFunction_ = JSObjectIsFunction,
+      .JSObjectMake_ = JSObjectMake,
+      .JSObjectMakeArray_ = JSObjectMakeArray,
+      .JSObjectMakeDate_ = JSObjectMakeDate,
+      .JSObjectMakeError_ = JSObjectMakeError,
+      .JSObjectMakeFunctionWithCallback_ = JSObjectMakeFunctionWithCallback,
+      .JSObjectSetPrivate_ = JSObjectSetPrivate,
+      .JSObjectSetProperty_ = JSObjectSetProperty,
+      .JSObjectSetPropertyAtIndex_ = JSObjectSetPropertyAtIndex,
 
-      .JSObjectCopyPropertyNames = JSObjectCopyPropertyNames,
-      .JSPropertyNameArrayGetCount = JSPropertyNameArrayGetCount,
-      .JSPropertyNameArrayGetNameAtIndex = JSPropertyNameArrayGetNameAtIndex,
-      .JSPropertyNameArrayRelease = JSPropertyNameArrayRelease,
+      .JSObjectCopyPropertyNames_ = JSObjectCopyPropertyNames,
+      .JSPropertyNameArrayGetCount_ = JSPropertyNameArrayGetCount,
+      .JSPropertyNameArrayGetNameAtIndex_ = JSPropertyNameArrayGetNameAtIndex,
+      .JSPropertyNameArrayRelease_ = JSPropertyNameArrayRelease,
 
-      .JSValueCreateJSONString = JSValueCreateJSONString,
-      .JSValueGetType = JSValueGetType,
-      .JSValueMakeFromJSONString = JSValueMakeFromJSONString,
-      .JSValueMakeBoolean = JSValueMakeBoolean,
-      .JSValueMakeNull = JSValueMakeNull,
-      .JSValueMakeNumber = JSValueMakeNumber,
-      .JSValueMakeString = JSValueMakeString,
-      .JSValueMakeUndefined = JSValueMakeUndefined,
-      .JSValueProtect = JSValueProtect,
-      .JSValueToBoolean = JSValueToBoolean,
-      .JSValueToNumber = JSValueToNumber,
-      .JSValueToObject = JSValueToObject,
-      .JSValueToStringCopy = JSValueToStringCopy,
-      .JSValueUnprotect = JSValueUnprotect,
+      .JSValueCreateJSONString_ = JSValueCreateJSONString,
+      .JSValueGetType_ = JSValueGetType,
+      .JSValueMakeFromJSONString_ = JSValueMakeFromJSONString,
+      .JSValueMakeBoolean_ = JSValueMakeBoolean,
+      .JSValueMakeNull_ = JSValueMakeNull,
+      .JSValueMakeNumber_ = JSValueMakeNumber,
+      .JSValueMakeString_ = JSValueMakeString,
+      .JSValueMakeUndefined_ = JSValueMakeUndefined,
+      .JSValueProtect_ = JSValueProtect,
+      .JSValueToBoolean_ = JSValueToBoolean,
+      .JSValueToNumber_ = JSValueToNumber,
+      .JSValueToObject_ = JSValueToObject,
+      .JSValueToStringCopy_ = JSValueToStringCopy,
+      .JSValueUnprotect_ = JSValueUnprotect,
 
-      .JSSamplingProfilerEnabled = JSSamplingProfilerEnabled,
-      .JSPokeSamplingProfiler =
+      .JSSamplingProfilerEnabled_ = JSSamplingProfilerEnabled,
+      .JSPokeSamplingProfiler_ =
         (decltype(&JSPokeSamplingProfiler))
         Unimplemented_JSPokeSamplingProfiler,
-      .JSStartSamplingProfilingOnMainJSCThread =
+      .JSStartSamplingProfilingOnMainJSCThread_ =
         (decltype(&JSStartSamplingProfilingOnMainJSCThread))
         Unimplemented_JSStartSamplingProfilingOnMainJSCThread,
 
-      .JSGlobalContextEnableDebugger =
+      .JSGlobalContextEnableDebugger_ =
         (decltype(&JSGlobalContextEnableDebugger))
         Unimplemented_JSGlobalContextEnableDebugger,
-      .JSGlobalContextDisableDebugger =
+      .JSGlobalContextDisableDebugger_ =
         (decltype(&JSGlobalContextDisableDebugger))
         Unimplemented_JSGlobalContextDisableDebugger,
 
-      .configureJSCForIOS =
+      .configureJSCForIOS_ =
         (decltype(&configureJSCForIOS))Unimplemented_configureJSCForIOS,
 
-      .JSContext = objc_getClass("JSContext"),
-      .JSValue = objc_getClass("JSValue"),
+      //.JSContext_ = objc_getClass("JSContext"),
+      //.JSValue_ = objc_getClass("JSValue"),
 
       .JSBytecodeFileFormatVersion = JSNoBytecodeFileFormatVersion,
     };
@@ -151,4 +160,3 @@ const JSCWrapper* systemJSCWrapper() {
 
 } }
 
-#endif

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -26,8 +26,86 @@ if (USE_QTWEBKIT)
   find_package(Qt5WebKit REQUIRED)
 endif()
 
+if(JAVASCRIPTCORE_ENABLED)
+  ADD_DEFINITIONS(-DJAVASCRIPTCORE_ENABLED)
+
+  include_directories("../../../ReactCommon")
+  include_directories("../../../ReactAndroid/src/main/jni/third-party")
+
+  include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
+  set(JavaScriptCore_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/JavaScriptCore_ep-prefix/src/JavaScriptCore_ep")
+  set(JavaScriptCore_INCLUDE_DIR "${JavaScriptCore_PREFIX}/WebKitBuild/Release/DerivedSources/ForwardingHeaders")
+  set(JavaScriptCore_STATIC_LIB
+      "${JavaScriptCore_PREFIX}/WebKitBuild/Release/lib/${CMAKE_STATIC_LIBRARY_PREFIX}JavaScriptCore${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(bmalloc_STATIC_LIB
+       "${JavaScriptCore_PREFIX}/WebKitBuild/Release/lib/${CMAKE_STATIC_LIBRARY_PREFIX}bmalloc${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(WTF_STATIC_LIB
+       "${JavaScriptCore_PREFIX}/WebKitBuild/Release/lib/${CMAKE_STATIC_LIBRARY_PREFIX}WTF${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+  include_directories(${JavaScriptCore_INCLUDE_DIR})
+
+  ExternalProject_Add(JavaScriptCore_ep
+    GIT_REPOSITORY git@github.com:WebKit/webkit.git
+    GIT_TAG 06fcd5bda23a9f4844263b60b33f2ad83be4d871
+    BUILD_BYPRODUCTS ${JavaScriptCore_STATIC_LIB}
+    CONFIGURE_COMMAND ${JavaScriptCore_PREFIX}/Tools/Scripts/build-webkit --jsc-only --cmakeargs="-DENABLE_STATIC_JSC=ON -DUSE_THIN_ARCHIVES=OFF"
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
+
+  set(FOLLY_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/folly_ep-prefix/src/folly_ep-install")
+  set(FOLLY_INCLUDE_DIR "${FOLLY_PREFIX}/include")
+  set(FOLLY_STATIC_LIB "${FOLLY_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}folly${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(FOLLY_CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX:PATH=${FOLLY_PREFIX}
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+
+  include_directories(${FOLLY_INCLUDE_DIR})
+  MESSAGE(STATUS "FOLLY_INCLUDE_DIR = ${FOLLY_INCLUDE_DIR}")
+
+  ExternalProject_Add(folly_ep
+        URL "https://github.com/facebook/folly/archive/v2018.04.30.00.tar.gz"
+        BUILD_BYPRODUCTS "${FOLLY_STATIC_LIB}"
+        CMAKE_ARGS ${FOLLY_CMAKE_ARGS})
+
+  set(
+    SRC_JAVASCRIPTCORE
+    ../../../ReactCommon/jschelpers/JSCHelpers.cpp
+    ../../../ReactCommon/jschelpers/Unicode.cpp
+    ../../../ReactCommon/jschelpers/Value.cpp
+    ../../../ReactCommon/jschelpers/JSCWrapper.cpp
+    ../../../ReactCommon/jschelpers/systemJSCWrapper.cpp
+
+    ../../../ReactCommon/jsinspector/InspectorInterfaces.cpp
+
+    ../../../ReactCommon/privatedata/PrivateDataBase.cpp
+
+    ../../../ReactCommon/cxxreact/CxxNativeModule.cpp
+    ../../../ReactCommon/cxxreact/Instance.cpp
+    ../../../ReactCommon/cxxreact/JSBigString.cpp
+    ../../../ReactCommon/cxxreact/JSBundleType.cpp
+    ../../../ReactCommon/cxxreact/JSCExecutor.cpp
+    ../../../ReactCommon/cxxreact/JSCLegacyTracing.cpp
+    ../../../ReactCommon/cxxreact/JSCMemory.cpp
+    ../../../ReactCommon/cxxreact/JSCNativeModules.cpp
+    ../../../ReactCommon/cxxreact/JSCPerfStats.cpp
+    ../../../ReactCommon/cxxreact/JSCSamplingProfiler.cpp
+    ../../../ReactCommon/cxxreact/JSCTracing.cpp
+    ../../../ReactCommon/cxxreact/JSCUtils.cpp
+    ../../../ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
+    ../../../ReactCommon/cxxreact/MethodCall.cpp
+    ../../../ReactCommon/cxxreact/ModuleRegistry.cpp
+    ../../../ReactCommon/cxxreact/NativeToJsBridge.cpp
+    ../../../ReactCommon/cxxreact/Platform.cpp
+    ../../../ReactCommon/cxxreact/RAMBundleRegistry.cpp
+    jscutilities.cpp
+    communication/javascriptcoreexecutor.cpp)
+endif()
+
 set(
   SRC_RUNTIME
+  ${SRC_JAVASCRIPTCORE}
   reactplugin.cpp
   valuecoercion.cpp
   blobprovider.cpp
@@ -125,6 +203,7 @@ add_library(
   ${QML}
   react_resources.qrc
 )
+
 set_target_properties(
   react-native
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY React
@@ -137,6 +216,20 @@ endif()
 
 if (REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS)
   target_link_libraries(react-native ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS})
+endif()
+
+if(JAVASCRIPTCORE_ENABLED)
+  add_dependencies(react-native JavaScriptCore_ep folly_ep)
+
+  target_link_libraries(react-native
+    ${JavaScriptCore_STATIC_LIB} ${bmalloc_STATIC_LIB} ${WTF_STATIC_LIB}
+    "-licudata"
+    "-licui18n"
+    "-licuuc"
+    "-lglog"
+    "-ldouble-conversion"
+    ${FOLLY_STATIC_LIB}
+  )
 endif()
 
 include_directories(${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS})

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -18,6 +18,8 @@
 #include <QScopedPointer>
 #include <QUrl>
 
+#include <functional>
+
 class QQuickItem;
 class QQmlEngine;
 class QNetworkAccessManager;
@@ -100,6 +102,15 @@ public:
 
     void setHotReload(bool value);
 
+    void partialBatchDidFlush();
+    void batchDidComplete();
+
+    void* getJavaScriptContext();
+    void executeOnJavaScriptThread(std::function<void()> func);
+
+    void loadSource();
+    void initModules();
+
 Q_SIGNALS:
     void readyChanged();
     void jsAppStartedChanged();
@@ -110,8 +121,6 @@ private Q_SLOTS:
     void applicationScriptDone();
 
 private:
-    void loadSource();
-    void initModules();
     void loadExternalModules(QObjectList* modules);
     void injectModules();
     void processResult(const QJsonDocument& document);

--- a/ReactQt/runtime/src/communication/javascriptcoreexecutor.cpp
+++ b/ReactQt/runtime/src/communication/javascriptcoreexecutor.cpp
@@ -1,0 +1,209 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifdef JAVASCRIPTCORE_ENABLED
+
+#include "javascriptcoreexecutor.h"
+
+#include "bridge.h"
+#include "jscutilities.h"
+
+#include "cxxreact/Instance.h"
+#include "cxxreact/JSBigString.h"
+#include <cxxreact/MessageQueueThread.h>
+
+#include <QDebug>
+#include <QThread>
+#include <QTimer>
+
+using namespace facebook::react;
+
+typedef std::function<void(QString error)> RCTJavaScriptCompleteBlock;
+typedef std::function<void(int result, QString error)> RCTJavaScriptCallback;
+
+namespace facebook {
+namespace react {
+
+class RCTMessageThread : public QObject, public MessageQueueThread {
+    Q_OBJECT
+public:
+    RCTMessageThread(RCTJavaScriptCompleteBlock errorBlock);
+    ~RCTMessageThread() override;
+    void runOnQueue(std::function<void()>&&) override;
+    void runOnQueueSync(std::function<void()>&&) override;
+    void quitSynchronous() override;
+    void setRunLoop();
+
+Q_SIGNALS:
+    void sheduleRun(std::function<void()>);
+
+private Q_SLOTS:
+    void execFunc(std::function<void()>);
+
+private:
+    void tryFunc(const std::function<void()>& func);
+    void runAsync(std::function<void()> func);
+    void runSync(std::function<void()> func);
+
+    std::atomic_bool m_shutdown;
+    QThread m_thread;
+};
+
+RCTMessageThread::RCTMessageThread(RCTJavaScriptCompleteBlock errorBlock) : m_shutdown(false) {
+    qRegisterMetaType<std::function<void()>>("std::function<void()>");
+    this->moveToThread(&m_thread);
+
+    connect(this, &RCTMessageThread::sheduleRun, this, &RCTMessageThread::execFunc, Qt::QueuedConnection);
+    m_thread.start();
+}
+
+RCTMessageThread::~RCTMessageThread() {}
+
+// This is analogous to dispatch_async
+void RCTMessageThread::runAsync(std::function<void()> func) {}
+
+// This is analogous to dispatch_sync
+void RCTMessageThread::runSync(std::function<void()> func) {}
+
+void RCTMessageThread::tryFunc(const std::function<void()>& func) {}
+
+void RCTMessageThread::execFunc(std::function<void()> func) {
+    func();
+}
+
+void RCTMessageThread::runOnQueue(std::function<void()>&& func) {
+    if (m_shutdown) {
+        return;
+    }
+
+    emit sheduleRun(func);
+}
+
+void RCTMessageThread::runOnQueueSync(std::function<void()>&& func) {
+    if (m_shutdown) {
+        return;
+    }
+
+    func();
+}
+
+void RCTMessageThread::quitSynchronous() {
+    m_shutdown = true;
+}
+
+void RCTMessageThread::setRunLoop() {}
+}
+}
+
+struct RCTInstanceCallback : public InstanceCallback {
+    Bridge* bridge_;
+    RCTInstanceCallback(Bridge* bridge) : bridge_(bridge) {}
+    void onBatchComplete() override {
+        // There's no interface to call this per partial batch
+        bridge_->partialBatchDidFlush();
+        bridge_->batchDidComplete();
+    }
+};
+
+class JavaScriptCoreExecutorPrivate : public QObject {
+    Q_OBJECT
+public:
+    JavaScriptCoreExecutorPrivate(JavaScriptCoreExecutor* e) {}
+
+public:
+    std::shared_ptr<RCTMessageThread> _jsMessageThread;
+    std::shared_ptr<Instance> _reactInstance;
+    Bridge* bridge = nullptr;
+};
+
+JavaScriptCoreExecutor::JavaScriptCoreExecutor(QObject* parent)
+    : IExecutor(parent), d_ptr(new JavaScriptCoreExecutorPrivate(this)) {
+    Q_D(JavaScriptCoreExecutor);
+}
+
+JavaScriptCoreExecutor::~JavaScriptCoreExecutor() {}
+
+void JavaScriptCoreExecutor::injectJson(const QString& name, const QVariant& data) {}
+
+void JavaScriptCoreExecutor::executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl) {
+    Q_D(JavaScriptCoreExecutor);
+    d->_jsMessageThread->runOnQueue([=] {
+        d->_reactInstance->loadScriptFromString(
+            std::make_unique<JSBigStdString>(script.toStdString()), sourceUrl.toString().toStdString(), true);
+        d->bridge->setReady(true);
+    });
+}
+
+void JavaScriptCoreExecutor::executeJSCall(const QString& method,
+                                           const QVariantList& args,
+                                           const IExecutor::ExecuteCallback& callback) {
+    // Q_ASSERT(args.size() == 3);
+    if (args.size() != 3)
+        return;
+    d_func()->_reactInstance->callJSFunction(args.at(0).toString().toStdString(),
+                                             args.at(1).toString().toStdString(),
+                                             utilities::qvariantToDynamic(args.at(2).toList()));
+}
+
+void* JavaScriptCoreExecutor::getJavaScriptContext() {
+    Q_D(JavaScriptCoreExecutor);
+    if (d->_reactInstance.get()) {
+        return d->_reactInstance->getJavaScriptContext();
+    } else {
+        return nullptr;
+    }
+}
+
+void JavaScriptCoreExecutor::executeOnJavaScriptThread(std::function<void()> func) {
+    Q_D(JavaScriptCoreExecutor);
+    d->_jsMessageThread->runOnQueue(std::function<void()>(func));
+}
+
+void JavaScriptCoreExecutor::setBridge(Bridge* bridge) {
+    Q_D(JavaScriptCoreExecutor);
+    d->bridge = bridge;
+}
+
+void JavaScriptCoreExecutor::init() {
+    Q_D(JavaScriptCoreExecutor);
+    Q_ASSERT(d->bridge);
+
+    std::shared_ptr<JSExecutorFactory> executorFactory;
+    executorFactory.reset(new JSCExecutorFactory(folly::dynamic::object("OwnerIdentity", "ReactNative")(
+        "AppIdentity", "ReactNativeApp")("DeviceIdentity", "unknown")("UseCustomJSC", false)));
+
+    d->_jsMessageThread = std::make_shared<RCTMessageThread>([=](QString error) {
+        if (error.isEmpty()) {
+        }
+    });
+
+    std::shared_ptr<ModuleRegistry> moduleRegistry;
+    moduleRegistry.reset(new ModuleRegistry(std::vector<std::unique_ptr<NativeModule>>(), [=](const std::string& name) {
+        qDebug() << "Native module \"" << name.c_str() << "\" not found !";
+        return false;
+    }));
+
+    d->_reactInstance.reset(new Instance);
+
+    d->bridge->initModules();
+    moduleRegistry->registerModules(d->bridge->modules());
+
+    d->_jsMessageThread->runOnQueue([=] {
+        d->_reactInstance->initializeBridge(
+            std::make_unique<RCTInstanceCallback>(d->bridge), executorFactory, d->_jsMessageThread, moduleRegistry);
+    });
+
+    QTimer::singleShot(500, [=]() { d->bridge->loadSource(); });
+}
+
+#include "javascriptcoreexecutor.moc"
+
+#endif // JAVASCRIPTCORE_ENABLED

--- a/ReactQt/runtime/src/communication/javascriptcoreexecutor.h
+++ b/ReactQt/runtime/src/communication/javascriptcoreexecutor.h
@@ -1,0 +1,56 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef JAVASCRIPTCOREEXECUTOR_H
+#define JAVASCRIPTCOREEXECUTOR_H
+
+#ifdef JAVASCRIPTCORE_ENABLED
+
+#include <functional>
+
+#include <QUrl>
+
+#include "iexecutor.h"
+
+class Bridge;
+
+class JavaScriptCoreExecutorPrivate;
+class JavaScriptCoreExecutor : public IExecutor {
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(JavaScriptCoreExecutor)
+
+public:
+    typedef std::function<void(const QJsonDocument&)> ExecuteCallback;
+
+    JavaScriptCoreExecutor(QObject* parent = nullptr);
+    ~JavaScriptCoreExecutor();
+
+    virtual void init();
+
+    virtual void injectJson(const QString& name, const QVariant& data);
+    virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl);
+    virtual void executeJSCall(const QString& method,
+                               const QVariantList& args = QVariantList(),
+                               const ExecuteCallback& callback = ExecuteCallback());
+
+    void executeApplicationScriptOnSocketReady();
+
+    void* getJavaScriptContext();
+    void executeOnJavaScriptThread(std::function<void()> func);
+    void setBridge(Bridge* bridge);
+
+private:
+    QScopedPointer<JavaScriptCoreExecutorPrivate> d_ptr;
+};
+
+#endif // JAVASCRIPTCORE_ENABLED
+
+#endif // JAVASCRIPTCOREEXECUTOR_H

--- a/ReactQt/runtime/src/jscutilities.cpp
+++ b/ReactQt/runtime/src/jscutilities.cpp
@@ -1,0 +1,28 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "jscutilities.h"
+
+#include <QJsonDocument>
+
+namespace utilities {
+
+folly::dynamic qvariantToDynamic(const QVariant& value) {
+    QJsonDocument doc = QJsonDocument::fromVariant(value);
+    return folly::parseJson(doc.toJson(QJsonDocument::Compact).toStdString());
+}
+
+QVariant dynamicToQVariant(const folly::dynamic& value) {
+    std::string jsonStr = folly::toJson(value);
+    return QJsonDocument::fromJson(jsonStr.c_str()).toVariant();
+}
+
+} // namespace utilities

--- a/ReactQt/runtime/src/jscutilities.h
+++ b/ReactQt/runtime/src/jscutilities.h
@@ -1,0 +1,29 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef JSCUTILITIES
+#define JSCUTILITIES
+
+#include <QVariant>
+
+#include <folly/json.h>
+
+class QQuickItem;
+class QQmlEngine;
+
+namespace utilities {
+
+folly::dynamic qvariantToDynamic(const QVariant& value);
+QVariant dynamicToQVariant(const folly::dynamic& value);
+
+} // namespace utilities
+
+#endif // JSCUTILITIES

--- a/ReactQt/runtime/src/modulemethod.h
+++ b/ReactQt/runtime/src/modulemethod.h
@@ -23,8 +23,8 @@ class Bridge;
 
 enum class NativeMethodType { Async, Promise, Sync };
 
-class ModuleMethod {
-
+class ModuleMethod : public QObject {
+    Q_OBJECT
 public:
     typedef std::function<QObject*(QVariantList&)> ObjectFunction;
 
@@ -34,7 +34,7 @@ public:
     QString name() const;
     NativeMethodType type() const;
 
-    void invoke(const QVariantList& args);
+    Q_INVOKABLE void invoke(const QVariantList& args);
 
 private:
     ObjectFunction m_objectFunction;

--- a/local-cli/generator-desktop/templates/CMakeLists.txt
+++ b/local-cli/generator-desktop/templates/CMakeLists.txt
@@ -8,6 +8,16 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
+option(JAVASCRIPTCORE_ENABLED
+    "Build with JavaScriptCore enabled"
+    OFF)
+
+if(JAVASCRIPTCORE_ENABLED)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 set(APP_NAME <%= name %>)
 set(REACT_BUILD_STATIC_LIB ON)
 


### PR DESCRIPTION
Optional JavaScriptCore engine support on Linux:

- CMAKE option -DJAVASCRIPTCORE_ENABLED should be specified to enable build of JavaScriptCore and Facebook folly libs + react-native-desktop sources related to JavaScriptCore. (**ATTENTION**: Building of JavaScriptCore requires at least 8GB RAM, took 10+ GB of disk space and downloads 8GB of data from WebKit GitHub repository, lasts 15+ minutes)
- JavaScriptCoreExecutor class introduced to encapsulate all internal work related to JavaScriptCore 