### PR TITLE
Windows react-native-desktop build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ project(react-native-desktop)
 set(PROJECT_NAME "react-native-desktop")
 set(PROJECT_VERSION "0.0.1")
 
+if(WIN32)
+  set(REACT_BUILD_STATIC_LIB 1)
+endif()
+
 include_directories(./React/Layout)
 enable_testing()
 

--- a/Examples/2048/CMakeLists.txt
+++ b/Examples/2048/CMakeLists.txt
@@ -8,5 +8,5 @@ configure_file(
 
 add_custom_target(
   copy-${EXAMPLE_NAME} ALL
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/Examples/Movies/CMakeLists.txt
+++ b/Examples/Movies/CMakeLists.txt
@@ -8,5 +8,5 @@ configure_file(
 
 add_custom_target(
   copy-${EXAMPLE_NAME} ALL
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/Examples/UIExplorer/CMakeLists.txt
+++ b/Examples/UIExplorer/CMakeLists.txt
@@ -8,5 +8,5 @@ configure_file(
 
 add_custom_target(
   copy-${EXAMPLE_NAME} ALL
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/RNTester/CMakeLists.txt
+++ b/RNTester/CMakeLists.txt
@@ -8,5 +8,5 @@ configure_file(
 
 add_custom_target(
   copy-${EXAMPLE_NAME} ALL
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/qml/${EXAMPLE_NAME}.qml ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -35,9 +35,15 @@ configure_file(
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../runtime/src)
 
+if (APPLICATION_MAIN_CPP_PATH)
+  set(MAIN_CPP_SOURCE ${APPLICATION_MAIN_CPP_PATH})
+else()
+set(MAIN_CPP_SOURCE main.cpp)
+endif()
+
 add_executable(
   ${APP_NAME}
-  main.cpp
+  ${MAIN_CPP_SOURCE}
   main.qrc
 )
 

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -97,6 +97,7 @@ set(
   qml/ReactTextInputArea.qml
   qml/ReactTextInputField.qml
   qml/ReactAlert.qml
+  qml/ReactWebView.qml
 )
 
 if(DEFINED REACT_BUILD_STATIC_LIB)
@@ -131,7 +132,7 @@ qt5_use_modules(react-native ${USED_QT_MODULES})
 
 add_custom_target(
   copy-qmldir ALL
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${CMAKE_CURRENT_BINARY_DIR}/React
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${CMAKE_CURRENT_BINARY_DIR}/React
 )
 
 configure_file(../../../ubuntu-server.js ../../../ubuntu-server.js COPYONLY)

--- a/local-cli/desktop/buildDesktop.js
+++ b/local-cli/desktop/buildDesktop.js
@@ -117,12 +117,15 @@ function _buildApplication(args, desktopExternalModules, desktopJSBundlePath) {
   return new Promise((resolve, reject) => {
     console.log(chalk.bold('Building the app...'));
 
-    var buildCommand = './build.sh';
+    var buildCommand = process.platform === "win32" ? "build.bat" : "./build.sh";
     if (typeof desktopExternalModules !== 'undefined' && desktopExternalModules !== null) {
-      buildCommand += ' -e="' + desktopExternalModules.toString().replace(/,/g, ';') + '"';
+      buildCommand += ' -e "' + desktopExternalModules.toString().replace(/,/g, ';') + '"';
     }
     if (typeof desktopJSBundlePath !== 'undefined' && desktopJSBundlePath !== null) {
-      buildCommand += ' -j="' + desktopJSBundlePath.toString() + '"';
+      buildCommand += ' -j "' + desktopJSBundlePath.toString() + '"';
+    }
+    if (process.platform === "win32") {
+      buildCommand += ' -g "' + "MinGW Makefiles" + '"';
     }
     child_process.exec(buildCommand, {cwd: path.join(args.root, 'desktop')},
                         (error, stdout, stderr) => {

--- a/local-cli/desktop/runDesktop.js
+++ b/local-cli/desktop/runDesktop.js
@@ -79,7 +79,7 @@ function actuallyRun(args, reject) {
       if (args['arch'].startsWith('arm'))
         appArgs.push('--on-device');
       appArgs.push('--plugins-path=' + args['plugins-path']);
-      child_process.spawnSync('./run-app.sh', appArgs,
+      child_process.spawnSync(process.platform === "win32" ? 'run-app.bat' : './run-app.sh', appArgs,
                               {stdio: 'inherit'});
   } catch (e) {
     console.log(chalk.red('Could not start the app, see the error above.'));
@@ -90,11 +90,19 @@ function actuallyRun(args, reject) {
 }
 
 function startPackagerInNewWindow() {
-  child_process.spawn('gnome-terminal',['-e', 'npm start'],{detached: true});
+  if (process.platform === "win32") {
+    child_process.spawn('cmd', ['/c', 'npm start'],{detached: true});
+  } else {
+    child_process.spawn('gnome-terminal',['-e', 'npm start'],{detached: true});
+  }
 }
 
 function startUbuntuServerInNewWindow() {
-  child_process.spawn('gnome-terminal', ['-e', 'node ./desktop/bin/ubuntu-server.js'],{detached: true});
+  if (process.platform === "win32") {
+    child_process.spawn('cmd', ['/c', 'node ./desktop/bin/ubuntu-server.js'],{detached: true});
+  } else {
+    child_process.spawn('gnome-terminal', ['-e', 'node ./desktop/bin/ubuntu-server.js'],{detached: true});
+  }
 }
 
 module.exports = {

--- a/local-cli/generator-desktop/index.js
+++ b/local-cli/generator-desktop/index.js
@@ -72,6 +72,12 @@ module.exports = yeoman.generators.NamedBase.extend({
       templateParams
     );
 
+    // Custom application main.cpp source
+    this.fs.copyTpl(
+      this.templatePath('../../../ReactQt/application/src/main.cpp'),
+      this.destinationPath(path.join('desktop', 'main.cpp')),
+      templateParams
+    );
     // click
     this.fs.copyTpl(
       this.templatePath('click/manifest.json'),

--- a/local-cli/generator-desktop/index.js
+++ b/local-cli/generator-desktop/index.js
@@ -54,14 +54,16 @@ module.exports = yeoman.generators.NamedBase.extend({
       this.destinationPath(path.join('desktop', 'CMakeLists.txt')),
       templateParams
     );
+    var buildScriptPath = process.platform === "win32" ? "build.bat" : "build.sh";
     this.fs.copyTpl(
-      this.templatePath('build.sh'),
-      this.destinationPath(path.join('desktop', 'build.sh')),
+      this.templatePath(buildScriptPath),
+      this.destinationPath(path.join('desktop', buildScriptPath)),
       templateParams
     );
+    var runScriptPath = process.platform === "win32" ? "run-app.bat.in" : "run-app.sh.in";
     this.fs.copyTpl(
-      this.templatePath('run-app.sh.in'),
-      this.destinationPath(path.join('desktop', 'run-app.sh.in')),
+      this.templatePath(runScriptPath),
+      this.destinationPath(path.join('desktop', runScriptPath)),
       templateParams
     );
     this.fs.copyTpl(

--- a/local-cli/generator-desktop/templates/CMakeLists.txt
+++ b/local-cli/generator-desktop/templates/CMakeLists.txt
@@ -18,6 +18,9 @@ foreach(external_module ${EXTERNAL_MODULES_DIR})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../${external_module} ${CMAKE_CURRENT_BINARY_DIR}/${external_module})
 endforeach(external_module)
 
+# APPLICATION_MAIN_CPP_PATH contains absolute path to generated template copy of main.cpp for application executable
+get_filename_component(APPLICATION_MAIN_CPP_PATH main.cpp ABSOLUTE)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/React/Layout)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/runtime/src ${CMAKE_CURRENT_BINARY_DIR}/lib)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/application/src ${CMAKE_CURRENT_BINARY_DIR}/bin)

--- a/local-cli/generator-desktop/templates/CMakeLists.txt
+++ b/local-cli/generator-desktop/templates/CMakeLists.txt
@@ -22,9 +22,15 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/Rea
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/runtime/src ${CMAKE_CURRENT_BINARY_DIR}/lib)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../node_modules/react-native/ReactQt/application/src ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
+if (WIN32)
+  set(RUN_SCRIPT_FILE_NAME "run-app.bat")
+else()
+  set(RUN_SCRIPT_FILE_NAME "run-app.sh")
+endif()
+
 configure_file(
-  run-app.sh.in
-  ${CMAKE_CURRENT_BINARY_DIR}/run-app.sh
+  ${RUN_SCRIPT_FILE_NAME}.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${RUN_SCRIPT_FILE_NAME}
   @ONLY
 )
 

--- a/local-cli/generator-desktop/templates/build.bat
+++ b/local-cli/generator-desktop/templates/build.bat
@@ -1,0 +1,34 @@
+@rem Copyright (c) 2017-present, Status Research and Development GmbH.
+@rem All rights reserved.
+@rem
+@rem This source code is licensed under the BSD-style license found in the
+@rem LICENSE file in the root directory of this source tree. An additional grant
+@rem of patent rights can be found in the PATENTS file in the same directory. 
+
+@echo off
+setlocal EnableDelayedExpansion
+
+set "option="
+for %%a in (%*) do (
+   if not defined option (
+      set arg=%%a
+      if "!arg:~0,1!" equ "-" set "option=!arg!"
+   ) else (
+      set "option!option!=%%a"
+      set "option="
+   )
+)
+
+SET option
+@echo on
+
+echo "build.bat external modules paths: "%option-e%
+echo "build.bat JS bundle path: "%option-j%
+echo "build.bat cmake generator: "%option-g%
+
+@rem Workaround
+@rem rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile
+
+@rem Build project
+echo %CD%
+cmake -DCMAKE_BUILD_TYPE=Debug -G %option-g% -DEXTERNAL_MODULES_DIR=%option-e% -DJS_BUNDLE_PATH=%option-j% . && cmake --build .

--- a/local-cli/generator-desktop/templates/build.sh
+++ b/local-cli/generator-desktop/templates/build.sh
@@ -12,9 +12,9 @@ cd $(dirname $0)
 for i in "$@"
 do
 case $i in
-  -e=*|--externalModulesPaths=*)
+  -e\ *|--externalModulesPaths\ *)
   ExternalModulesPaths="${i#*=}" ;;
-  -j=*|--jsBundlePath=*)
+  -j\ *|--jsBundlePath\ *)
   JsBundlePath="${i#*=}" ;;
 esac
 done

--- a/local-cli/generator-desktop/templates/run-app.bat.in
+++ b/local-cli/generator-desktop/templates/run-app.bat.in
@@ -1,0 +1,11 @@
+@rem Copyright (c) 2017-present, Status Research and Development GmbH.
+@rem All rights reserved.
+@rem
+@rem This source code is licensed under the BSD-style license found in the
+@rem LICENSE file in the root directory of this source tree. An additional grant
+@rem of patent rights can be found in the PATENTS file in the same directory.
+
+
+@rem Run app locally
+@CMAKE_BINARY_DIR@/bin/@APP_NAME@
+


### PR DESCRIPTION
- Resolves build issues on Windows (MinGW toolchain)
- Repairs cli commands on Windows to build and start custom app
- "react-native desktop" command copies main.cpp of custom app into generated `desktop` directory. It replaces original main.cpp during build process.