### PR TITLE
refs #225 - Use QtWebKit on Windows with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PROJECT_VERSION "0.0.1")
 
 if(WIN32)
   set(REACT_BUILD_STATIC_LIB 1)
+  set(USE_QTWEBKIT 1)
 endif()
 
 include_directories(./React/Layout)

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -17,6 +17,10 @@ find_package(Qt5Quick REQUIRED)
 find_package(Qt5WebSockets REQUIRED)
 find_package(Qt5Svg REQUIRED)
 
+if (USE_QTWEBKIT)
+  find_package(Qt5WebKit REQUIRED)
+endif()
+
 # Format EXTERNAL_MODULES to contain array of external modules type names defined as strings
 string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}")
 
@@ -49,6 +53,9 @@ add_executable(
 )
 
 set(USED_QT_MODULES Core Qml Quick WebSockets Svg)
+if (USE_QTWEBKIT)
+  set (USED_QT_MODULES ${USED_QT_MODULES} Webkit)
+endif()
 
 qt5_use_modules(${APP_NAME} ${USED_QT_MODULES})
 

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -22,6 +22,10 @@ find_package(Qt5Quick REQUIRED)
 find_package(Qt5WebSockets REQUIRED)
 find_package(Qt5Svg REQUIRED)
 
+if (USE_QTWEBKIT)
+  find_package(Qt5WebKit REQUIRED)
+endif()
+
 set(
   SRC_RUNTIME
   reactplugin.cpp
@@ -98,8 +102,14 @@ set(
   qml/ReactTextInputArea.qml
   qml/ReactTextInputField.qml
   qml/ReactAlert.qml
-  qml/ReactWebView.qml
 )
+
+if (USE_QTWEBKIT)
+  set(QML ${QML} qml/ReactQtWebKitWebView.qml)
+  ADD_DEFINITIONS(-DUSE_QTWEBKIT)
+else()
+  set(QML ${QML} qml/ReactWebView.qml)
+endif()
 
 if(DEFINED REACT_BUILD_STATIC_LIB)
 add_library(
@@ -132,6 +142,9 @@ endif()
 include_directories(${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS})
 
 set(USED_QT_MODULES Core Qml Quick WebSockets Svg)
+if (USE_QTWEBKIT)
+  set (USED_QT_MODULES ${USED_QT_MODULES} Webkit)
+endif()
 
 qt5_use_modules(react-native ${USED_QT_MODULES})
 

--- a/ReactQt/runtime/src/componentmanagers/webviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/webviewmanager.cpp
@@ -40,7 +40,12 @@ QString WebViewManager::moduleName() {
 }
 
 QString WebViewManager::qmlComponentFile() const {
-    return "qrc:/qml/ReactWebView.qml";
+#ifdef USE_QTWEBKIT
+    const QString reactWebViewComponent = QStringLiteral("qrc:/qml/ReactQtWebKitWebView.qml");
+#else
+    const QString reactWebViewComponent = QStringLiteral("qrc:/qml/ReactWebView.qml");
+#endif
+    return reactWebViewComponent;
 }
 
 void WebViewManager::configureView(QQuickItem* view) const {

--- a/ReactQt/runtime/src/qml/ReactQtWebKitWebView.qml
+++ b/ReactQt/runtime/src/qml/ReactQtWebKitWebView.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+
+import QtWebKit 3.0
+import React 0.1 as React
+
+WebView {
+    id: webViewRoot
+    property var p_source: ''
+    property var webViewManager: null
+    property var flexbox: React.Flexbox {control: webViewRoot}
+
+    onWebViewManagerChanged: {
+        if (!webViewManager) {
+            return;
+        }
+        webViewManager.s_reload.connect(webViewRoot.reload);
+        webViewManager.s_goBack.connect(webViewRoot.goBack);
+        webViewManager.s_goForward.connect(webViewRoot.goForward);
+    }
+
+    onP_sourceChanged: {
+        webViewRoot.url = (p_source && p_source.uri) ? p_source.uri : "";
+        if(p_source && p_source.html) {
+            webViewRoot.loadHtml(p_source.html)
+        }
+    }
+
+}

--- a/ReactQt/runtime/src/react_resources.qrc
+++ b/ReactQt/runtime/src/react_resources.qrc
@@ -19,6 +19,7 @@
         <file>qml/ReactTextInputArea.qml</file>
         <file>qml/ReactTextInputField.qml</file>
         <file>qml/ReactWebView.qml</file>
+        <file>qml/ReactQtWebKitWebView.qml</file>
         <file>qml/ReactAlert.qml</file>
     </qresource>
 </RCC>

--- a/local-cli/generator-desktop/templates/CMakeLists.txt
+++ b/local-cli/generator-desktop/templates/CMakeLists.txt
@@ -11,6 +11,10 @@ cmake_minimum_required(VERSION 2.8.11)
 set(APP_NAME <%= name %>)
 set(REACT_BUILD_STATIC_LIB ON)
 
+if (WIN32)
+  set(USE_QTWEBKIT 1)
+endif()
+
 message(STATUS "EXTERNAL_MODULES_DIR: ${EXTERNAL_MODULES_DIR}")
 
 foreach(external_module ${EXTERNAL_MODULES_DIR})


### PR DESCRIPTION
- `USE_QTWEBKIT` cmake and C preprocessor flag is introduced to enable optional dependency on QtWebKit QML plugin.
- New added `ReactQtWebKitWebView.qml` is mostly the copy of original `ReactWebView.qml` with the difference in referencing QtWebKit qml component instead of QtWebView. I was not able to find more elegant solution here: QML doesn't support preprocessor directives and it's not possible to know in advance if some QML module exists or not (referencing of not available module fails loading of whole QML file even if components from failed to load module are not used).