### PR TITLE
Support external projects dependencies of main lib

### DIFF
--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -121,6 +121,10 @@ set_target_properties(
 )
 endif()
 
+if (REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS)
+  add_dependencies(react-native ${REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS})
+endif()
+
 if (REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS)
   target_link_libraries(react-native ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS})
 endif()


### PR DESCRIPTION
CMake variable `REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS` introduced to define external main library target dependency. It should define an order of build chain and allow more straightforward support of cmake external projects from 3rd party react-native modules with Desktop platform.