### PR TITLE
Modifiers added to press event in TextInput

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -90,8 +90,8 @@ void TextInputManager::sendOnFocusToJs(QQuickItem* textInput) {
     sendTextInputEvent(textInput, EVENT_ON_FOCUS);
 }
 
-void TextInputManager::sendOnKeyPressToJs(QQuickItem* textInput, QString keyText) {
-    sendTextInputEvent(textInput, EVENT_ON_KEY_PRESS, QVariantMap{{"key", keyText}});
+void TextInputManager::sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QStringList modifiers) {
+    sendTextInputEvent(textInput, EVENT_ON_KEY_PRESS, QVariantMap{{"key", keyText}, {"modifiers", modifiers}});
 }
 
 void TextInputManager::sendOnContentSizeChange(QQuickItem* textInput, double width, double height) {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.h
@@ -36,7 +36,7 @@ public slots:
     void sendOnSubmitEditingToJs(QQuickItem* textInput);
     void sendOnEndEditingToJs(QQuickItem* textInput);
     void sendOnFocusToJs(QQuickItem* textInput);
-    void sendOnKeyPressToJs(QQuickItem* textInput, QString keyText);
+    void sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QStringList modifiers);
     void sendOnContentSizeChange(QQuickItem* textInput, double width, double height);
 
 private:

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -61,6 +61,26 @@ Item {
         return t;
     }
 
+    function keyModifiers(modifiers) {
+        var modArray = [];
+
+        if(modifiers & Qt.ShiftModifier) {
+            modArray.push("shift")
+        }
+        if(modifiers & Qt.ControlModifier) {
+            modArray.push("control")
+        }
+        if(modifiers & Qt.AltModifier) {
+            modArray.push("alt")
+        }
+        if(modifiers & Qt.MetaModifier) {
+            modArray.push("meta")
+        }
+
+        return modArray;
+    }
+
+
     Component.onCompleted: recreateInputControl();
     onP_multilineChanged: recreateInputControl();
 }

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -33,7 +33,9 @@ Flickable {
 
         onTextChanged: textInputRoot.textInputManager.sendTextEditedToJs(textField)
         onCursorPositionChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
-        Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField, textInputRoot.keyText(event.key, event.text))
+        Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField,
+                                                            textInputRoot.keyText(event.key, event.text),
+                                                            textInputRoot.keyModifiers(event.modifiers))
         onContentSizeChanged: {
             if(textInputManager)
                 textInputManager.sendOnContentSizeChange(textField, contentWidth, contentHeight)

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -33,7 +33,9 @@ TextField {
         if(textInputManager)
             textInputManager.sendOnContentSizeChange(textField, contentWidth, contentHeight)
     }
-    Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField, textInputRoot.keyText(event.key, event.text))
+    Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField,
+                                                        textInputRoot.keyText(event.key, event.text),
+                                                        textInputRoot.keyModifiers(event.modifiers))
 
     onFocusChanged: {
         if (focus) {


### PR DESCRIPTION
Added information about pressed key modifiers to TextInput onKeyPress event.

p.s. original react native doesn't have this option since it is used on mobile devices