### PR TITLE
Reset visual item parent on item delete request

### DIFF
--- a/ReactQt/runtime/src/uimanager.cpp
+++ b/ReactQt/runtime/src/uimanager.cpp
@@ -108,6 +108,7 @@ void UIManager::removeChildren(QQuickItem* parent, const QList<int>& removeAtInd
             int childTag = AttachedProperties::get(child)->tag();
             child->setParent(0);
             m_views.remove(childTag);
+            child->setParentItem(nullptr);
             child->deleteLater();
         }
 


### PR DESCRIPTION
The change should resolve UI glitches, for example, on array of react-native components (issues with messages list in status-react app).
Description of issue:
- react-native has optimization to render UI components defined inside array. It's implemented inside function reconcileChildrenArray ( file `Libraries/Renderer/ReactNativeRenderer-dev.js` ). On recalculation old instances might be reused for new components instances.
- Sometimes arrays optimization deletes multiple UI components one by one too fast and QML scene is not able to recalculate child items for the parent container from where we resolve indexes of child items to be removed.
- Setting setParentItem to nullptr seems asks parent to remove child from children list just on time of calling, so the issue is not occur any more.