### PR TITLE
fix markdown link in CreateNewApp.md

### DIFF
--- a/docs/ReactQt/CreateNewApp.md
+++ b/docs/ReactQt/CreateNewApp.md
@@ -1,6 +1,6 @@
 ## Overview
 
-To create react-native apps with `Desktop` platform support extended version of `react-native-cli` package should be [installed globally](docs/ReactQt/InstallUpdatedReactNativeCLI.md).  
+To create react-native apps with `Desktop` platform support extended version of `react-native-cli` package should be [installed globally](InstallUpdatedReactNativeCLI.md).
 
 In order to setup the RN-desktop project, execute these terminal commands:
 


### PR DESCRIPTION
was going through this and markdown link was returning a 404. 

now uses relative path for the same directory. 