### PR TITLE
documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ To access `In-App Developer Menu` ~~start shaking your laptop/PC~~ press CTRL+R.
 
 ### 3rd-party react-native modules support
 Pure JavaScript react-native modules can be used with react-native-desktop without limitations.  
-Creation of custom react-native `native` modules or `adopting of available native modules` is supported and described in following [guideline](docs/ReactQt/NativeModulesSupport.md).  
+Creation of custom react-native `native` modules or `adopting of available native modules` is supported and described in following [guideline](docs/NativeModulesSupport.md).
 
-[List of supported or partially supported native modules](docs/ReactQt/SupportedNativeModulesList.md).
+[List of supported or partially supported native modules](docs/SupportedNativeModulesList.md).
 
 ## Documentation
 
-- [How react-native-desktop works internally](docs/ReactQt/HowRNDesktopAppWorks.md)
-- [List of supported React Native components and APIs ("React Native Qt" column)](docs/ReactQt/ComponentsSupport.md)
+- [How react-native-desktop works internally](docs/HowRNDesktopAppWorks.md)
+- [List of supported React Native components and APIs ("React Native Qt" column)](docs/ComponentsSupport.md)
 - Follow [Ubuntu development guide](README-ubuntu.md) to get started building of react-native-desktop itself and JS apps based on it.
-- [Troubleshooting](docs/ReactQt/Troubleshooting.md)
+- [Troubleshooting](docs/Troubleshooting.md)
 
 ## ClojureScript React Native apps support
 
@@ -49,7 +49,7 @@ Any kind of contribution is welcome! Check the [list of opened issues](https://g
 
 - [Linux guide for React Native Desktop contributors](Development-linux.md)
 - [Yoga layout engine in react-native-desktop](YogaLayoutEngine.md)
-- [Using GammaRay for inspecting Qt internals](docs/ReactQt/InspectAppWithGammaRay.md)
+- [Using GammaRay for inspecting Qt internals](docs/InspectAppWithGammaRay.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Recommended Qt framework of version 5.9.1 LTS.
 
 ## Getting Started
 
-- [Install Prerequisites](docs/ReactQt/InstallPrerequisites.md)  
-- [Install adjusted react-native-cli](docs/ReactQt/InstallUpdatedReactNativeCLI.md)  
-- [Create new App](docs/ReactQt/CreateNewApp.md)  
+- [Install Prerequisites](docs/InstallPrerequisites.md)
+- [Install adjusted react-native-cli](docs/InstallUpdatedReactNativeCLI.md)
+- [Create new App](docs/CreateNewApp.md)
 
 
 ### Debugging

--- a/docs/CreateNewApp.md
+++ b/docs/CreateNewApp.md
@@ -7,7 +7,6 @@ In order to setup the RN-desktop project, execute these terminal commands:
 ```
 ~$ react-native init DesktopSampleApp && cd DesktopSampleApp
 ~/DesktopSampleApp$ react-native desktop
-~/DesktopSampleApp$ npm install
 
 ```
 If you're using macOS, run these commands in separate shells:


### PR DESCRIPTION
fix some links that weren't working as well as take out the `npm install` addition so that it isn't misleading.

For what it's worth, I experimented with removing the install block within `generator/index.js` but after re-installing `react-native-cli` I still received the yarn/npm issue on a newly created app. 

Would an additional command have to be run @MaxRis for any local changes to the cli tool in order for them to be bundled up and captured as part of a subsequent npm install? Or I could have simply been missing something. Let me know what you all think is sensible. Thanks! cc @madhavarshney  