### PR TITLE
Insert child QMLItem at specific position #253

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
           sudo add-apt-repository -y ppa:beineri/opt-qt591-trusty
           sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
           sudo apt-get -qy update
-          sudo apt-get install -y dbus xvfb curl cmake mesa-common-dev \
-              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative qt59websockets
+          sudo apt-get install -y --force-yes dbus xvfb curl cmake mesa-common-dev \
+              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative qt59websockets qt59svg
           echo "/opt/qt59/bin/qt59-env.sh" >> ~/.circlerc
 
       # Install node
@@ -54,16 +54,16 @@ jobs:
 
       # Build react-native-desktop in Debug (RCT_DEV enabled)
       - run: |
-          mkdir build_debug
-          pushd build_debug
-          cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j4
+          mkdir build_debug && \
+          pushd build_debug && \
+          cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j4 && \
           popd
 
       # Build react-native-desktop in Release
       - run: |
-          mkdir build
-          pushd build
-          cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4
+          mkdir build && \
+          pushd build && \
+          cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 && \
           popd
 
       # Download and cache dependencies
@@ -71,7 +71,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
 
       - run: |
-          rm -rf ./node_modules/metro
+          rm -rf ./node_modules/metro && \
           npm install
 
       # Apply metro patch to add desktop platform
@@ -97,6 +97,6 @@ jobs:
 
       # run unit tests
       - run: |
-          pushd build
-          xvfb-run --server-args="-screen 0 1024x768x24" ctest -VV
+          pushd build && \
+          xvfb-run --server-args="-screen 0 1024x768x24" ctest -VV && \
           popd

--- a/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
@@ -52,7 +52,7 @@ void ModalManager::addChildItem(QQuickItem* modalView, QQuickItem* child, int po
     // add to parents content item
     QQuickItem* contentItem = QQmlProperty(modalView, "contentItem").read().value<QQuickItem*>();
     Q_ASSERT(contentItem != nullptr);
-    child->setParentItem(contentItem);
+    utilities::insertChildItemAt(child, position, contentItem);
 }
 
 QStringList ModalManager::customDirectEventTypes() {

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -73,7 +73,7 @@ void ScrollViewManager::addChildItem(QQuickItem* scrollView, QQuickItem* child, 
     // add to parents content item
     QQuickItem* contentItem = QQmlProperty(scrollView, "contentItem").read().value<QQuickItem*>();
     Q_ASSERT(contentItem != nullptr);
-    child->setParentItem(contentItem);
+    utilities::insertChildItemAt(child, position, contentItem);
 }
 
 void ScrollViewManager::scrollBeginDrag() {

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -76,7 +76,7 @@ bool ViewManager::shouldLayout() const {
 }
 
 void ViewManager::addChildItem(QQuickItem* container, QQuickItem* child, int position) const {
-    child->setParentItem(container);
+    utilities::insertChildItemAt(child, position, container);
 }
 
 QQuickItem* ViewManager::view(const QVariantMap& properties) const {

--- a/ReactQt/runtime/src/uimanager.cpp
+++ b/ReactQt/runtime/src/uimanager.cpp
@@ -32,6 +32,7 @@
 #include "modulemethod.h"
 #include "reactitem.h"
 #include "uimanager.h"
+#include "utilities.h"
 
 int UIManager::m_nextRootTag = 1;
 
@@ -153,7 +154,7 @@ void UIManager::manageChildren(int containerReactTag,
             if (vm != nullptr) {
                 vm->addChildItem(container, child, i);
             } else {
-                child->setParentItem(container);
+                utilities::insertChildItemAt(child, i, container);
             }
 
             auto containerFlexbox = Flexbox::findFlexbox(container);

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -87,4 +87,20 @@ QObject* createQObjectInstance(const QString& typeName) {
     return mObj->newInstance();
 }
 
+void insertChildItemAt(QQuickItem* item, int position, QQuickItem* parent) {
+    if (!item || !parent)
+        return;
+
+    QList<QQuickItem*> childItems = parent->childItems();
+    for (int index = position; index < childItems.size(); ++index) {
+        childItems[index]->setParentItem(nullptr);
+    }
+
+    item->setParentItem(parent);
+
+    for (int index = position; index < childItems.size(); ++index) {
+        childItems[index]->setParentItem(parent);
+    }
+}
+
 } // namespace utilities

--- a/ReactQt/runtime/src/utilities.h
+++ b/ReactQt/runtime/src/utilities.h
@@ -24,6 +24,7 @@ void registerReactTypes();
 QString normalizeInputEventName(const QString& eventName);
 QQuickItem* createQMLItemFromSourceFile(QQmlEngine* qmlEngine, const QUrl& fileUrl);
 QObject* createQObjectInstance(const QString& typeName);
+void insertChildItemAt(QQuickItem* item, int position, QQuickItem* parent);
 
 } // namespace utilities
 

--- a/ReactQt/tests/CMakeLists.txt
+++ b/ReactQt/tests/CMakeLists.txt
@@ -25,6 +25,8 @@ set(REACT_TESTCASE_JS
   JS/TestTextInputProps.js
   JS/TestPickerProps.js
   JS/TestTextInputClear.js
+  JS/TestArrayReconciliationInsertFirst.js
+  JS/TestArrayReconciliationDeleteLast.js
 )
 
 set(
@@ -50,6 +52,7 @@ add_executable(test-textinput-props test-textinput-props.cpp resources.qrc ${REA
 add_executable(test-picker-props test-picker-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-netexecutor-socket test-netexecutor-socket.cpp ${REACT_TESTCASE_SRC})
 add_executable(test-textinput-clear test-textinput-clear.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
+add_executable(test-array-reconciliation test-array-reconciliation.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 
 
 add_test(test-integration test-integration)
@@ -63,6 +66,7 @@ add_test(test-textinput-props test-textinput-props)
 add_test(test-picker-props test-picker-props)
 add_test(test-netexecutor-socket test-netexecutor-socket)
 add_test(test-textinput-clear test-textinput-clear)
+add_test(test-array-reconciliation test-array-reconciliation)
 
 target_link_libraries(test-integration ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-image-props ${REACT_TESTCASE_LIBRARIES})
@@ -75,6 +79,7 @@ target_link_libraries(test-textinput-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-picker-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-netexecutor-socket ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-textinput-clear ${REACT_TESTCASE_LIBRARIES})
+target_link_libraries(test-array-reconciliation ${REACT_TESTCASE_LIBRARIES})
 
 set_target_properties(
   test-integration

--- a/ReactQt/tests/JS/TestArrayReconciliationDeleteLast.js
+++ b/ReactQt/tests/JS/TestArrayReconciliationDeleteLast.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import {
+ AppRegistry,
+ Alert,
+ Text,
+ TouchableHighlight,
+ View,
+ TextInput,
+ Button
+} from 'react-native';
+
+
+
+class ItemList extends Component {
+ constructor(props) {
+   super(props);
+   this.state = {longList: true};
+   this.onPress = this.onPress.bind(this);
+ }
+
+ onPress() {
+   this.setState({longList: !this.state.longList});
+ }
+
+ onButtonPress() {
+  this.setState({longList: !this.state.longList});
+ }
+
+ render() {
+   let items = this.state.longList ? ["FirstButton", "SecondButton", "ThirdButton"] : ["1stButton", "2ndButton"];
+   return (
+     <View onPress={this.onPress} nativeID={"topView"}>
+       {items.map(function(name, index) {
+         return <Button key={name} title={name} > </Button>;
+       })}
+     </View>
+   )
+ }
+}
+
+class TestArrayReconciliationDeleteLast extends Component {
+ render() {
+   return (
+     <ItemList />
+   );
+ }
+}
+
+AppRegistry.registerComponent('TestArrayReconciliationDeleteLast', () => TestArrayReconciliationDeleteLast);

--- a/ReactQt/tests/JS/TestArrayReconciliationInsertFirst.js
+++ b/ReactQt/tests/JS/TestArrayReconciliationInsertFirst.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import {
+ AppRegistry,
+ Alert,
+ Text,
+ TouchableHighlight,
+ View,
+ TextInput,
+ Button
+} from 'react-native';
+
+
+
+class ItemList extends Component {
+ constructor(props) {
+   super(props);
+   this.state = {longList: true};
+   this.onPress = this.onPress.bind(this);
+ }
+
+ onPress() {
+   this.setState({longList: !this.state.longList});
+ }
+
+ onButtonPress() {
+  this.setState({longList: !this.state.longList});
+ }
+
+ render() {
+   let items = this.state.longList ? ["FirstButton", "SecondButton", "ThirdButton"] : ["SecondButton", "ThirdButton"];
+   return (
+     <View onPress={this.onPress} nativeID={"topView"}>
+       {items.map(function(name, index) {
+         return <Button key={name} title={name} > </Button>;
+       })}
+     </View>
+   )
+ }
+}
+
+class TestArrayReconciliationInsertFirst extends Component {
+ render() {
+   return (
+     <ItemList />
+   );
+ }
+}
+
+AppRegistry.registerComponent('TestArrayReconciliationInsertFirst', () => TestArrayReconciliationInsertFirst);

--- a/ReactQt/tests/TestArrayReconciliation.qml
+++ b/ReactQt/tests/TestArrayReconciliation.qml
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+import QtQuick 2.4
+import React 0.1 as React
+
+Rectangle {
+    id: root
+    width: 640; height: 480;
+
+    React.RootView {
+        objectName: "rootView"
+        anchors.fill: parent
+
+        moduleName: "TestArrayReconciliationInsertFirst"
+        codeLocation: "http://localhost:8081/ReactQt/tests/JS/TestArrayReconciliationInsertFirst.bundle?platform=desktop&dev=true"
+    }
+}

--- a/ReactQt/tests/resources.qrc
+++ b/ReactQt/tests/resources.qrc
@@ -10,5 +10,6 @@
         <file>TestTextInputProps.qml</file>
         <file>TestPickerProps.qml</file>
         <file>TestTextInputClear.qml</file>
+        <file>TestArrayReconciliation.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/tests/test-array-reconciliation.cpp
+++ b/ReactQt/tests/test-array-reconciliation.cpp
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <QSignalSpy>
+#include <QTest>
+#include <QTimer>
+#include <QtQuick/QQuickView>
+
+#include "reacttestcase.h"
+#include "redbox.h"
+
+class TestArrayReconciliation : public ReactTestCase {
+    Q_OBJECT
+
+private slots:
+    virtual void initTestCase() override;
+    CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+
+    void testComponentsArrayFirstElementInsert();
+    void testComponentsArrayLastElementDelete();
+
+private:
+    QTimer* clickDelayTimer = nullptr;
+    QQuickItem* topView = nullptr;
+    const int INITIAL_ITEMS_COUNT = 3;
+    const int CLICKED_ITEMS_COUNT = 2;
+
+    void validateComponentsCount(const int expectedItemsCount, const QString& errorMsg);
+};
+
+void TestArrayReconciliation::initTestCase() {
+    ReactTestCase::initTestCase();
+
+    clickDelayTimer = new QTimer(this);
+    clickDelayTimer->setSingleShot(true);
+    clickDelayTimer->setInterval(1000);
+
+    loadQML(QUrl("qrc:/TestArrayReconciliation.qml"));
+    waitAndVerifyJsAppStarted();
+    showView();
+}
+
+void TestArrayReconciliation::validateComponentsCount(const int expectedItemsCount, const QString& errorMsg) {
+    clickDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
+    waitAndVerifyCondition([=]() { return topView->childItems().size() == expectedItemsCount; }, errorMsg);
+}
+
+void TestArrayReconciliation::testComponentsArrayFirstElementInsert() {
+    topView = topJSComponent();
+    QCOMPARE(valueOfControlProperty(topView, "objectName").toString(), QString("topView"));
+
+    QCOMPARE(topView->childItems().size(), INITIAL_ITEMS_COUNT);
+
+    QQuickItem* textInput = topView->childItems().at(0);
+    QCOMPARE(valueOfControlProperty(textInput, "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+
+    clickItem(textInput);
+
+    validateComponentsCount(CLICKED_ITEMS_COUNT, "Wrong array items count after 1st click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(INITIAL_ITEMS_COUNT, "Wrong array items count after 2nd click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(CLICKED_ITEMS_COUNT, "Wrong array items count after 3rd click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(INITIAL_ITEMS_COUNT, "Wrong array items count after 4th click");
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+}
+
+void TestArrayReconciliation::testComponentsArrayLastElementDelete() {
+    clickDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
+
+    loadJSBundle("TestArrayReconciliationDeleteLast", "ReactQt/tests/JS/TestArrayReconciliationDeleteLast");
+
+    waitAndVerifyJsAppStarted();
+    showView();
+
+    clickDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
+
+    topView = topJSComponent();
+    QCOMPARE(valueOfControlProperty(topView, "objectName").toString(), QString("topView"));
+
+    QCOMPARE(topView->childItems().size(), INITIAL_ITEMS_COUNT);
+
+    QQuickItem* textInput = topView->childItems().at(0);
+    QCOMPARE(valueOfControlProperty(textInput, "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+
+    clickItem(textInput);
+
+    validateComponentsCount(CLICKED_ITEMS_COUNT, "Wrong array items count after 1st click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(INITIAL_ITEMS_COUNT, "Wrong array items count after 2nd click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(CLICKED_ITEMS_COUNT, "Wrong array items count after 3rd click");
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(INITIAL_ITEMS_COUNT, "Wrong array items count after 4th click");
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+}
+
+QTEST_MAIN(TestArrayReconciliation)
+#include "test-array-reconciliation.moc"

--- a/ReactQt/tests/test-integration.cpp
+++ b/ReactQt/tests/test-integration.cpp
@@ -10,6 +10,7 @@
 
 #include <QSignalSpy>
 #include <QTest>
+#include <QTimer>
 #include <QtQuick/QQuickView>
 
 #include "bridge.h"
@@ -43,6 +44,12 @@ void TestIntegration::testTestModuleMarkTestCompleted() {
 }
 
 void TestIntegration::testJSExceptionReceived() {
+    QTimer* startupDelayTimer = new QTimer(this);
+    startupDelayTimer->setSingleShot(true);
+    startupDelayTimer->setInterval(1000);
+    startupDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !startupDelayTimer->isActive(); }, "Timer timeout was not triggered");
+
     loadJSBundle("TestJSException", "IntegrationTests/TestJSException");
 
     waitAndVerifyJsAppStarted();


### PR DESCRIPTION
- `UIManager::manageChildren` should insert childs at specific position in parent container, but not just add to the end as it does currently
- Unit tests to validate calling of `UIManager::manageChildren` in different contexts
- CI updates to fail sh commands if part of command fails

Closes https://github.com/status-im/react-native-desktop/issues/253

P.S. Just discovered that there are mysterious [QQuickItem::stackBefore](http://doc.qt.io/qt-5/qquickitem.html#stackBefore) and stackAfter to reorder the childs, but so far it's totally unclear how to use them properly.