### PR TITLE
Text loses selection when focus lost

### DIFF
--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -45,6 +45,11 @@ TextEdit {
     opacity: p_opacity
     readOnly: true
     selectByMouse: p_selectable
+    onActiveFocusChanged: {
+        if(!activeFocus && !persistentSelection) {
+            select(0,0)
+        }
+    }
 
 
     onP_allowFontScalingChanged: updateHtmlText();


### PR DESCRIPTION
When TextEdit loses focus it should remove the selection from TextEdit. That works fine when `readOnly` property set to `false` but doesn't work when it is set to `true` (like in our project).

This change fixes the issue.
