### PR TITLE
Added support of Linking.openURL() method

### DIFF
--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -130,6 +130,7 @@ set(
   redbox.cpp
   exceptionsmanager.cpp
   clipboard.cpp
+  linkingmanager.cpp
   alert.cpp
   componentmanagers/slidermanager.cpp
   componentmanagers/viewmanager.cpp

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -38,6 +38,7 @@
 #include "deviceinfo.h"
 #include "eventdispatcher.h"
 #include "exceptionsmanager.h"
+#include "linkingmanager.h"
 #include "moduledata.h"
 #include "moduleinterface.h"
 #include "moduleloader.h"
@@ -97,6 +98,7 @@ public:
                            new Networking,
                            new NetInfo,
                            new Clipboard,
+                           new LinkingManager,
                            new Alert,
                            new DeviceInfo,
                            new BlobProvider,

--- a/ReactQt/runtime/src/linkingmanager.cpp
+++ b/ReactQt/runtime/src/linkingmanager.cpp
@@ -1,0 +1,40 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "linkingmanager.h"
+#include "bridge.h"
+#include <QDesktopServices>
+
+class LinkingManagerPrivate {
+public:
+    Bridge* bridge = nullptr;
+};
+
+void LinkingManager::openURL(const QString& url,
+                             const ModuleInterface::ListArgumentBlock& resolve,
+                             const ModuleInterface::ListArgumentBlock& reject) {
+    Q_D(LinkingManager);
+    QDesktopServices::openUrl(QUrl(url));
+    resolve(d->bridge, QVariantList{});
+}
+
+LinkingManager::LinkingManager(QObject* parent) : QObject(parent), d_ptr(new LinkingManagerPrivate) {}
+
+LinkingManager::~LinkingManager() {}
+
+void LinkingManager::setBridge(Bridge* bridge) {
+    Q_D(LinkingManager);
+    d->bridge = bridge;
+}
+
+QString LinkingManager::moduleName() {
+    return "RCTLinkingManager";
+}

--- a/ReactQt/runtime/src/linkingmanager.h
+++ b/ReactQt/runtime/src/linkingmanager.h
@@ -1,0 +1,39 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef REACTLINKINGMANAGER_H
+#define REACTLINKINGMANAGER_H
+
+#include "moduleinterface.h"
+
+class LinkingManagerPrivate;
+class LinkingManager : public QObject, public ModuleInterface {
+    Q_OBJECT
+    Q_INTERFACES(ModuleInterface)
+    Q_DECLARE_PRIVATE(LinkingManager)
+
+    Q_INVOKABLE REACT_PROMISE void openURL(const QString& url,
+                                           const ModuleInterface::ListArgumentBlock& resolve,
+                                           const ModuleInterface::ListArgumentBlock& reject);
+
+public:
+    LinkingManager(QObject* parent = 0);
+    virtual ~LinkingManager();
+
+    void setBridge(Bridge* bridge) override;
+
+    QString moduleName() override;
+
+private:
+    QScopedPointer<LinkingManagerPrivate> d_ptr;
+};
+
+#endif // REACTLINKINGMANAGER_H

--- a/docs/ComponentsSupport.md
+++ b/docs/ComponentsSupport.md
@@ -60,7 +60,7 @@
 | InteractionManager          |                      |
 | Keyboard                    |                      |
 | LayoutAnimation             |                      |
-| Linking                     |                      |
+| Linking                     |  +/-                 |
 | NetInfo                     |                      |
 |                             |                      |
 | PanResponder                |                      |


### PR DESCRIPTION
Fixes #278 


Added `Linking` module and `openURL` function in it.
`Linking` in react-native documentation - https://facebook.github.io/react-native/docs/0.35/linking


Example code to open url:
`Linking.openURL("http://google.com")`