### PR TITLE
manageChildren extended to support move of components to new indices

### DIFF
--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -155,11 +155,7 @@ void Bridge::executeOnJavaScriptThread(std::function<void()> func) {
 void Bridge::setupExecutor() {
     Q_D(Bridge);
 
-    if (d->executor) {
-        d->executor->deleteLater();
-        d->executor = nullptr;
-        d->useJSC = false;
-    }
+    resetExecutor();
 #ifdef RCT_DEV
     if (d->remoteJSDebugging) {
         d->executor = new WebSocketExecutor(QUrl("ws://localhost:8081/debugger-proxy?role=client"), this);
@@ -190,6 +186,17 @@ void Bridge::setupExecutor() {
 
     connect(d->executor, SIGNAL(applicationScriptDone()), SLOT(applicationScriptDone()));
     d->executor->init();
+}
+
+void Bridge::resetExecutor() {
+    Q_D(Bridge);
+
+    if (d->executor) {
+        d->executor->resetConnection();
+        d->executor->deleteLater();
+        d->executor = nullptr;
+        d->useJSC = false;
+    }
 }
 
 void Bridge::init() {
@@ -224,6 +231,12 @@ void Bridge::reload() {
 void Bridge::loadBundle(const QUrl& bundleUrl) {
     setBundleUrl(bundleUrl);
     reload();
+}
+
+void Bridge::reset() {
+    setReady(false);
+    setJsAppStarted(false);
+    resetExecutor();
 }
 
 void Bridge::enqueueJSCall(const QString& module, const QString& method, const QVariantList& args) {

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -57,6 +57,7 @@ public:
     void init();
     void reload();
     void loadBundle(const QUrl& bundleUrl);
+    void reset();
 
     void invokePromiseCallback(double callbackCode, const QVariantList& args);
     void enqueueJSCall(const QString& module, const QString& method, const QVariantList& args);
@@ -125,6 +126,7 @@ private:
     void injectModules();
     void processResult(const QJsonDocument& document);
     void setupExecutor();
+    void resetExecutor();
     void setJsAppStarted(bool started);
     void invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args);
     void addModuleData(QObject* module);

--- a/ReactQt/runtime/src/communication/executor.cpp
+++ b/ReactQt/runtime/src/communication/executor.cpp
@@ -51,7 +51,7 @@ Executor::Executor(ServerConnection* conn, QObject* parent) : IExecutor(parent),
 }
 
 Executor::~Executor() {
-    d_ptr->connection()->device()->close();
+    resetConnection();
 }
 
 void ExecutorPrivate::setupStateMachine() {
@@ -108,6 +108,10 @@ ServerConnection* ExecutorPrivate::connection() {
 
 void Executor::init() {
     d_ptr->m_machina->start();
+}
+
+void Executor::resetConnection() {
+    d_ptr->connection()->device()->close();
 }
 
 void ExecutorPrivate::processRequests() {

--- a/ReactQt/runtime/src/communication/executor.h
+++ b/ReactQt/runtime/src/communication/executor.h
@@ -34,6 +34,7 @@ public:
     ~Executor();
 
     virtual void init();
+    virtual void resetConnection();
 
     virtual void injectJson(const QString& name, const QVariant& data);
     virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl);

--- a/ReactQt/runtime/src/communication/iexecutor.h
+++ b/ReactQt/runtime/src/communication/iexecutor.h
@@ -28,6 +28,7 @@ public:
     virtual ~IExecutor() {}
 
     virtual void init() = 0;
+    virtual void resetConnection() = 0;
 
     virtual void injectJson(const QString& name, const QVariant& data) = 0;
     virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl) = 0;

--- a/ReactQt/runtime/src/communication/websocketexecutor.h
+++ b/ReactQt/runtime/src/communication/websocketexecutor.h
@@ -32,6 +32,7 @@ public:
     ~WebSocketExecutor();
 
     virtual void init();
+    virtual void resetConnection() {}
 
     virtual void injectJson(const QString& name, const QVariant& data);
     virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl);

--- a/ReactQt/runtime/src/uimanager.h
+++ b/ReactQt/runtime/src/uimanager.h
@@ -86,7 +86,7 @@ public:
     QQuickItem* viewForTag(int reactTag);
 
 private:
-    void removeChildren(QQuickItem* parent, const QList<int>& removeAtIndices);
+    void removeChildren(QQuickItem* parent, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
 
 private:
     static int m_nextRootTag;

--- a/ReactQt/tests/CMakeLists.txt
+++ b/ReactQt/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(REACT_TESTCASE_JS
   JS/TestTextInputClear.js
   JS/TestArrayReconciliationInsertFirst.js
   JS/TestArrayReconciliationDeleteLast.js
+  JS/TestArrayReconciliationItemMove.js
 )
 
 set(

--- a/ReactQt/tests/JS/TestArrayReconciliationItemMove.js
+++ b/ReactQt/tests/JS/TestArrayReconciliationItemMove.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import {
+ AppRegistry,
+ Alert,
+ Text,
+ TouchableHighlight,
+ View,
+ TextInput,
+ Button
+} from 'react-native';
+
+
+
+class ItemList extends Component {
+ constructor(props) {
+   super(props);
+   this.state = {longList: true,
+                 itemsList: ["FirstButton", "SecondButton", "ThirdButton", "FourthButton"] };
+   this.onPress = this.onPress.bind(this);
+ }
+
+ onPress() {
+   let removedItems = this.state.itemsList.splice(0, 1);
+   this.state.itemsList.push(removedItems[0]);
+   this.setState({longList: !this.state.longList,
+                  itemsList: this.state.itemsList});
+ }
+
+ render() {
+   return (
+     <View onPress={this.onPress} nativeID={"topView"}>
+       {this.state.itemsList.map(function(name, index) {
+         return <Button key={name} title={name} > </Button>;
+       })}
+     </View>
+   )
+ }
+}
+
+class TestArrayReconciliationItemMove extends Component {
+ render() {
+   return (
+     <ItemList />
+   );
+ }
+}
+
+AppRegistry.registerComponent('TestArrayReconciliationItemMove', () => TestArrayReconciliationItemMove);

--- a/ReactQt/tests/test-array-reconciliation.cpp
+++ b/ReactQt/tests/test-array-reconciliation.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QtQuick/QQuickView>
 
+#include "bridge.h"
 #include "reacttestcase.h"
 #include "redbox.h"
 
@@ -21,16 +22,20 @@ class TestArrayReconciliation : public ReactTestCase {
 
 private slots:
     virtual void initTestCase() override;
+    void init();
+    void cleanup();
     CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
 
     void testComponentsArrayFirstElementInsert();
     void testComponentsArrayLastElementDelete();
+    void testComponentsArrayItemMove();
 
 private:
     QTimer* clickDelayTimer = nullptr;
     QQuickItem* topView = nullptr;
     const int INITIAL_ITEMS_COUNT = 3;
     const int CLICKED_ITEMS_COUNT = 2;
+    const int CLICK_TIMER_DELAY = 1000;
 
     void validateComponentsCount(const int expectedItemsCount, const QString& errorMsg);
 };
@@ -40,11 +45,22 @@ void TestArrayReconciliation::initTestCase() {
 
     clickDelayTimer = new QTimer(this);
     clickDelayTimer->setSingleShot(true);
-    clickDelayTimer->setInterval(1000);
+    clickDelayTimer->setInterval(CLICK_TIMER_DELAY);
 
     loadQML(QUrl("qrc:/TestArrayReconciliation.qml"));
     waitAndVerifyJsAppStarted();
     showView();
+}
+
+void TestArrayReconciliation::init() {
+    clickDelayTimer->setInterval(4000);
+    clickDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
+    clickDelayTimer->setInterval(CLICK_TIMER_DELAY);
+}
+
+void TestArrayReconciliation::cleanup() {
+    bridge()->reset();
 }
 
 void TestArrayReconciliation::validateComponentsCount(const int expectedItemsCount, const QString& errorMsg) {
@@ -89,9 +105,6 @@ void TestArrayReconciliation::testComponentsArrayFirstElementInsert() {
 }
 
 void TestArrayReconciliation::testComponentsArrayLastElementDelete() {
-    clickDelayTimer->start();
-    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
-
     loadJSBundle("TestArrayReconciliationDeleteLast", "ReactQt/tests/JS/TestArrayReconciliationDeleteLast");
 
     waitAndVerifyJsAppStarted();
@@ -132,6 +145,58 @@ void TestArrayReconciliation::testComponentsArrayLastElementDelete() {
     QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("FirstButton"));
     QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
     QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+}
+
+void TestArrayReconciliation::testComponentsArrayItemMove() {
+    const int ARRAY_ITEMS_COUNT = 4;
+
+    loadJSBundle("TestArrayReconciliationItemMove", "ReactQt/tests/JS/TestArrayReconciliationItemMove");
+
+    waitAndVerifyJsAppStarted();
+    showView();
+
+    clickDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
+
+    topView = topJSComponent();
+    QCOMPARE(valueOfControlProperty(topView, "objectName").toString(), QString("topView"));
+
+    QCOMPARE(topView->childItems().size(), ARRAY_ITEMS_COUNT);
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("ThirdButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(3), "p_title").toString(), QString("FourthButton"));
+
+    QQuickItem* textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(ARRAY_ITEMS_COUNT, "Wrong array items count after 1st click");
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("ThirdButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("FourthButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(3), "p_title").toString(), QString("FirstButton"));
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(ARRAY_ITEMS_COUNT, "Wrong array items count after 2nd click");
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("ThirdButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("FourthButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(3), "p_title").toString(), QString("SecondButton"));
+
+    textInput = topView->childItems().at(0);
+    clickItem(textInput);
+
+    validateComponentsCount(ARRAY_ITEMS_COUNT, "Wrong array items count after 3rd click");
+
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(0), "p_title").toString(), QString("FourthButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(1), "p_title").toString(), QString("FirstButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(2), "p_title").toString(), QString("SecondButton"));
+    QCOMPARE(valueOfControlProperty(topView->childItems().at(3), "p_title").toString(), QString("ThirdButton"));
 }
 
 QTEST_MAIN(TestArrayReconciliation)


### PR DESCRIPTION
- uimanager::manageChildren extended to support `moveFromIndicies` and `moveToIndices` input params. (This functionality is used to move already available components views to new indexes in parent's list of children
- unit test to cover usage of `moveFromIndicies` and `moveToIndices` input params.
- Bridge extended with reset() method to reset Executor's connection. ( Keeping of old connection opened caused undesired data received on next unit test startup )
- TestArrayReconciliation extended with `cleanup` and `init` reserved by Qt's unit tests to be called on each test* method execution. `init` introduces timer delay (to allow socket connection to purge the data from previous connection) on each test* method start. `cleanup` resets the bridge instance, mainly, to close socket connection.