### PR TITLE
Insert QQuickItem with QQuickItem::stackBefore

### DIFF
--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -92,14 +92,12 @@ void insertChildItemAt(QQuickItem* item, int position, QQuickItem* parent) {
         return;
 
     QList<QQuickItem*> childItems = parent->childItems();
-    for (int index = position; index < childItems.size(); ++index) {
-        childItems[index]->setParentItem(nullptr);
-    }
-
-    item->setParentItem(parent);
-
-    for (int index = position; index < childItems.size(); ++index) {
-        childItems[index]->setParentItem(parent);
+    if (childItems.size() && childItems.size() > position) {
+        QQuickItem* nextItem = childItems.at(position);
+        item->setParentItem(parent);
+        item->stackBefore(nextItem);
+    } else {
+        item->setParentItem(parent);
     }
 }
 


### PR DESCRIPTION
Looping over parent's children to insert new child at specific position is replaced with usage of [QQuickItem::stackBefore](http://doc.qt.io/qt-5/qquickitem.html#stackBefore), which seems [has optimization](https://code.woboq.org/qt5/qtdeclarative/src/quick/items/qquickitem.cpp.html#2834) to do the same.

Related to https://github.com/status-im/status-react/issues/5112 (the speed of switching between chats might be a little bit improved)