### PR TITLE
Resolves ui issue on redbox dismiss press

### DIFF
--- a/ReactQt/runtime/src/alert.cpp
+++ b/ReactQt/runtime/src/alert.cpp
@@ -45,7 +45,7 @@ void AlertPrivate::createAlertItem(const QVariantMap& config, double callback) {
         return;
     }
 
-    alert->setParentItem(bridge->visualParent()->parentItem());
+    alert->setParentItem(bridge->topmostVisualParent());
     alert->setObjectName("Alert");
     alert->setProperty("alertManager", QVariant::fromValue((QObject*)q_ptr));
     alert->setProperty("buttons", generateQmlButtonsList(config));

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -315,6 +315,10 @@ void Bridge::setVisualParent(QQuickItem* item) {
     d->visualParent = item;
 }
 
+QQuickItem* Bridge::topmostVisualParent() const {
+    return visualParent()->parentItem();
+}
+
 QQmlEngine* Bridge::qmlEngine() const {
     return d_func()->qmlEngine;
 }

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -74,6 +74,8 @@ public:
     QQuickItem* visualParent() const;
     void setVisualParent(QQuickItem* item);
 
+    QQuickItem* topmostVisualParent() const;
+
     QQmlEngine* qmlEngine() const;
     void setQmlEngine(QQmlEngine* qmlEngine);
 

--- a/ReactQt/runtime/src/redbox.cpp
+++ b/ReactQt/runtime/src/redbox.cpp
@@ -116,8 +116,7 @@ void Redbox::showErrorMessage(const QString& message, const QList<QVariantMap>& 
     d->redbox->setProperty(REDBOX_MESSAGE_PROPERTY, message);
     d->setStack(stack);
 
-    QQuickItem* rootView = d->bridge->visualParent();
-    d->redbox->setParentItem(rootView);
+    d->redbox->setParentItem(d->bridge->topmostVisualParent());
 }
 
 void Redbox::updateErrorMessage(const QString& message, const QList<QVariantMap>& stack) {


### PR DESCRIPTION
- Introduced Bridge::topmostVisualParent() to resolve top most visual QQuickItem to which is safe to insert dynamically created QML items, such as DevMenu, Alert box or RedBox.
- RedBox visual parent fixed ( on dismiss there are no ui issues anymore )