### PR TITLE
Support react-native-popup-menu library

### DIFF
--- a/Libraries/Utilities/BackHandler.desktop.js
+++ b/Libraries/Utilities/BackHandler.desktop.js
@@ -1,14 +1,35 @@
 /**
- * Copyright (c) 2017-present, Status Research and Development GmbH.
- * All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * On Apple TV, this implements back navigation using the TV remote's menu button.
+ * On iOS, this just implements a stub.
  *
  * @providesModule BackHandler
- * @flow
  */
+
 'use strict';
 
-module.exports = require('UnimplementedView');
+const Platform = require('Platform');
+
+type BackPressEventName = $Enum<{
+  backPress: string,
+}>;
+
+function emptyFunction() {}
+
+let BackHandler;
+
+BackHandler = {
+  exitApp: emptyFunction,
+  addEventListener() {
+    return {
+      remove: emptyFunction,
+    };
+  },
+  removeEventListener: emptyFunction,
+};
+
+module.exports = BackHandler;


### PR DESCRIPTION
This PR fixes issue #256.

Problems with `react-native-popup-menu` were the following:
1) `react-native-popup-menu` has no support for `desktop` platform in one small place, so I created PR in their repository requesting that changes - https://github.com/instea/react-native-popup-menu/pull/116
Until it is merged you can use forked project in status: https://github.com/status-im/react-native-popup-menu

2) Popup menu uses `BackHandler` and we had an incorrect implementation of it. I reused the one from ios. It also doesn't do anything but doesn't crash :)


This is how menu looks on desktop:
<img width="386" alt="screen shot 2018-07-26 at 1 45 19 pm" src="https://user-images.githubusercontent.com/5786310/43258071-3043f780-90da-11e8-87a0-0c259024140a.png">
