### PR TITLE
Move Executor to separate thread

### DIFF
--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -66,6 +66,7 @@
 #include <QPluginLoader>
 #include <QQuickItem>
 #include <QStandardPaths>
+#include <QThread>
 #include <QTimer>
 
 class BridgePrivate {
@@ -89,6 +90,7 @@ public:
     bool remoteJSDebugging = false;
     bool hotReload = false;
     QVariantList externalModules;
+    QThread* executorThread = nullptr;
 
     bool useJSC = false;
 
@@ -128,7 +130,9 @@ Bridge::Bridge(QObject* parent) : QObject(parent), d_ptr(new BridgePrivate) {
     d->eventDispatcher = new EventDispatcher(this);
 }
 
-Bridge::~Bridge() {}
+Bridge::~Bridge() {
+    resetExecutor();
+}
 
 void* Bridge::getJavaScriptContext() {
     Q_D(Bridge);
@@ -174,6 +178,10 @@ void Bridge::setupExecutor() {
 #endif // JAVASCRIPTCORE_ENABLED
 
     if (!d->executor) {
+        if (!d->executorThread) {
+            d->executorThread = new QThread();
+        }
+        d->executorThread->start();
         ServerConnection* conn =
             qobject_cast<ServerConnection*>(utilities::createQObjectInstance(d->serverConnectionType));
 
@@ -183,21 +191,28 @@ void Bridge::setupExecutor() {
             conn = new LocalServerConnection();
         }
 
-        d->executor = new Executor(conn, this);
+        d->executor = new Executor(conn);
+        conn->moveToThread(d->executorThread);
+        d->executor->moveToThread(d->executorThread);
     }
 
     connect(d->executor, SIGNAL(applicationScriptDone()), SLOT(applicationScriptDone()));
-    d->executor->init();
+    QMetaObject::invokeMethod(d_func()->executor, "init", Qt::AutoConnection);
 }
 
 void Bridge::resetExecutor() {
     Q_D(Bridge);
 
     if (d->executor) {
-        d->executor->resetConnection();
+        QMetaObject::invokeMethod(d_func()->executor, "resetConnection", Qt::AutoConnection);
         d->executor->deleteLater();
         d->executor = nullptr;
         d->useJSC = false;
+
+        if (d->executorThread) {
+            d->executorThread->deleteLater();
+            d->executorThread = nullptr;
+        }
     }
 }
 
@@ -244,23 +259,39 @@ void Bridge::reset() {
 void Bridge::enqueueJSCall(const QString& module, const QString& method, const QVariantList& args) {
     if (!d_func()->executor)
         return;
-    d_func()->executor->executeJSCall("callFunctionReturnFlushedQueue",
-                                      QVariantList{module, method, args},
-                                      [=](const QJsonDocument& doc) { processResult(doc); });
+    QVariantList list = QVariantList{module, method, args};
+    QMetaObject::invokeMethod(
+        d_func()->executor,
+        "executeJSCall",
+        Qt::AutoConnection,
+        Q_ARG(const QString&, "callFunctionReturnFlushedQueue"),
+        Q_ARG(const QVariantList&, list),
+        Q_ARG(const Executor::ExecuteCallback&, [=](const QJsonDocument& doc) { processResult(doc); }));
 }
 
 void Bridge::invokePromiseCallback(double callbackCode, const QVariantList& args) {
     if (!d_func()->executor)
         return;
-    d_func()->executor->executeJSCall("invokeCallbackAndReturnFlushedQueue",
-                                      QVariantList{callbackCode, args},
-                                      [=](const QJsonDocument& doc) { processResult(doc); });
+    QVariantList list = QVariantList{callbackCode, args};
+    QMetaObject::invokeMethod(
+        d_func()->executor,
+        "executeJSCall",
+        Qt::AutoConnection,
+        Q_ARG(const QString&, "invokeCallbackAndReturnFlushedQueue"),
+        Q_ARG(const QVariantList&, list),
+        Q_ARG(const Executor::ExecuteCallback&, [=](const QJsonDocument& doc) { processResult(doc); }));
 }
 
 void Bridge::invokeAndProcess(const QString& method, const QVariantList& args) {
     if (!d_func()->executor)
         return;
-    d_func()->executor->executeJSCall(method, args, [=](const QJsonDocument& doc) { processResult(doc); });
+    QMetaObject::invokeMethod(
+        d_func()->executor,
+        "executeJSCall",
+        Qt::AutoConnection,
+        Q_ARG(const QString&, method),
+        Q_ARG(const QVariantList&, args),
+        Q_ARG(const Executor::ExecuteCallback&, [=](const QJsonDocument& doc) { processResult(doc); }));
 }
 
 void Bridge::executeSourceCode(const QByteArray& sourceCode) {
@@ -271,12 +302,16 @@ void Bridge::enqueueRunAppCall(const QVariantList& args) {
     if (!d_func()->executor)
         return;
 
-    d_func()->executor->executeJSCall("callFunctionReturnFlushedQueue",
-                                      QVariantList{"AppRegistry", "runApplication", args},
-                                      [=](const QJsonDocument& doc) {
-                                          processResult(doc);
-                                          setJsAppStarted(true);
-                                      });
+    QVariantList list = QVariantList{"AppRegistry", "runApplication", args};
+    QMetaObject::invokeMethod(d_func()->executor,
+                              "executeJSCall",
+                              Qt::AutoConnection,
+                              Q_ARG(QString, "callFunctionReturnFlushedQueue"),
+                              Q_ARG(QVariantList, list),
+                              Q_ARG(Executor::ExecuteCallback, [=](const QJsonDocument& doc) {
+                                  processResult(doc);
+                                  setJsAppStarted(true);
+                              }));
 }
 
 bool Bridge::ready() const {
@@ -430,19 +465,27 @@ void Bridge::setHotReload(bool value) {
 void Bridge::sourcesFinished() {
     Q_D(Bridge);
     QTimer::singleShot(0, [=] {
-        d->executor->executeApplicationScript(d->sourceCode->sourceCode(), d->bundleUrl);
+        QMetaObject::invokeMethod(d->executor,
+                                  "executeApplicationScript",
+                                  Qt::AutoConnection,
+                                  Q_ARG(QByteArray, d->sourceCode->sourceCode()),
+                                  Q_ARG(QUrl, d->bundleUrl));
         if (d_func()->hotReload) {
-            d_func()->executor->executeJSCall("callFunctionReturnFlushedQueue",
-                                              QVariantList{"HMRClient",
-                                                           "enable",
-                                                           QVariantList{"desktop",
-                                                                        d->sourceCode->scriptUrl().path().mid(1),
-                                                                        d->sourceCode->scriptUrl().host(),
-                                                                        d->sourceCode->scriptUrl().port(0)}},
-                                              [=](const QJsonDocument& doc) {
-                                                  qDebug() << "Enabling HMRClient response";
-                                                  processResult(doc);
-                                              });
+            QVariantList args = QVariantList{"HMRClient",
+                                             "enable",
+                                             QVariantList{"desktop",
+                                                          d->sourceCode->scriptUrl().path().mid(1),
+                                                          d->sourceCode->scriptUrl().host(),
+                                                          d->sourceCode->scriptUrl().port(0)}};
+            QMetaObject::invokeMethod(d_func()->executor,
+                                      "executeJSCall",
+                                      Qt::AutoConnection,
+                                      Q_ARG(const QString&, "callFunctionReturnFlushedQueue"),
+                                      Q_ARG(const QVariantList&, args),
+                                      Q_ARG(const Executor::ExecuteCallback&, [=](const QJsonDocument& doc) {
+                                          qDebug() << "Enabling HMRClient response";
+                                          processResult(doc);
+                                      }));
         }
     });
 }
@@ -540,7 +583,12 @@ void Bridge::injectModules() {
         moduleConfig.push_back(md->info());
     }
 
-    d->executor->injectJson("__fbBatchedBridgeConfig", QVariantMap{{"remoteModuleConfig", moduleConfig}});
+    QVariant remoteConfig = QVariantMap{{"remoteModuleConfig", moduleConfig}};
+    QMetaObject::invokeMethod(d_func()->executor,
+                              "injectJson",
+                              Qt::AutoConnection,
+                              Q_ARG(const QString&, "__fbBatchedBridgeConfig"),
+                              Q_ARG(const QVariant&, remoteConfig));
 }
 
 void Bridge::processResult(const QJsonDocument& doc) {
@@ -563,7 +611,12 @@ void Bridge::processResult(const QJsonDocument& doc) {
     // XXX: this should all really be wrapped up in a Module class
     // including invocations etc
     for (int i = 0; i < moduleIDs.size(); ++i) {
-        invokeModuleMethod(moduleIDs[i].toInt(), methodIDs[i].toInt(), paramArrays[i].toList());
+        QMetaObject::invokeMethod(this,
+                                  "invokeModuleMethod",
+                                  Qt::AutoConnection,
+                                  Q_ARG(int, moduleIDs[i].toInt()),
+                                  Q_ARG(int, methodIDs[i].toInt()),
+                                  Q_ARG(QList<QVariant>, paramArrays[i].toList()));
     }
 }
 
@@ -590,12 +643,15 @@ void Bridge::invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args
 
 void Bridge::applicationScriptDone() {
     QTimer::singleShot(0, [this]() {
-        d_func()->executor->executeJSCall("flushedQueue",
-                                          QVariantList{},
-                                          [=](const QJsonDocument& doc) {
-                                              processResult(doc);
-                                              setReady(true);
-                                          });
+        QMetaObject::invokeMethod(d_func()->executor,
+                                  "executeJSCall",
+                                  Qt::AutoConnection,
+                                  Q_ARG(const QString&, "flushedQueue"),
+                                  Q_ARG(const QVariantList&, QVariantList()),
+                                  Q_ARG(const Executor::ExecuteCallback&, [=](const QJsonDocument& doc) {
+                                      processResult(doc);
+                                      setReady(true);
+                                  }));
     });
 }
 

--- a/ReactQt/runtime/src/bridge.h
+++ b/ReactQt/runtime/src/bridge.h
@@ -130,7 +130,7 @@ private:
     void setupExecutor();
     void resetExecutor();
     void setJsAppStarted(bool started);
-    void invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args);
+    Q_INVOKABLE void invokeModuleMethod(int moduleId, int methodId, QList<QVariant> args);
     void addModuleData(QObject* module);
 
     QScopedPointer<BridgePrivate> d_ptr;

--- a/ReactQt/runtime/src/communication/executor.cpp
+++ b/ReactQt/runtime/src/communication/executor.cpp
@@ -17,7 +17,7 @@
 
 class ExecutorPrivate : public QObject {
 public:
-    ExecutorPrivate(Executor* e) : q_ptr(e) {}
+    ExecutorPrivate(Executor* e) : QObject(e), q_ptr(e) {}
 
     virtual ServerConnection* connection();
     void processRequests();
@@ -47,7 +47,7 @@ Executor::Executor(ServerConnection* conn, QObject* parent) : IExecutor(parent),
     d->m_connection = QSharedPointer<ServerConnection>(conn);
     connect(d->connection(), &ServerConnection::dataReady, d, &ExecutorPrivate::readReply);
 
-    d->setupStateMachine();
+    qRegisterMetaType<Executor::ExecuteCallback>();
 }
 
 Executor::~Executor() {
@@ -107,6 +107,7 @@ ServerConnection* ExecutorPrivate::connection() {
 }
 
 void Executor::init() {
+    d_ptr->setupStateMachine();
     d_ptr->m_machina->start();
 }
 

--- a/ReactQt/runtime/src/communication/executor.h
+++ b/ReactQt/runtime/src/communication/executor.h
@@ -33,17 +33,19 @@ public:
     Executor(ServerConnection* conn, QObject* parent = nullptr);
     ~Executor();
 
-    virtual void init();
-    virtual void resetConnection();
+    Q_INVOKABLE virtual void init();
+    Q_INVOKABLE virtual void resetConnection();
 
-    virtual void injectJson(const QString& name, const QVariant& data);
-    virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl);
-    virtual void executeJSCall(const QString& method,
-                               const QVariantList& args = QVariantList(),
-                               const ExecuteCallback& callback = ExecuteCallback());
+    Q_INVOKABLE virtual void injectJson(const QString& name, const QVariant& data);
+    Q_INVOKABLE virtual void executeApplicationScript(const QByteArray& script, const QUrl& sourceUrl);
+    Q_INVOKABLE virtual void executeJSCall(const QString& method,
+                                           const QVariantList& args = QVariantList(),
+                                           const Executor::ExecuteCallback& callback = ExecuteCallback());
 
 private:
     QScopedPointer<ExecutorPrivate> d_ptr;
 };
+
+Q_DECLARE_METATYPE(Executor::ExecuteCallback)
 
 #endif // EXECUTOR_H

--- a/ReactQt/tests/reacttestcase.cpp
+++ b/ReactQt/tests/reacttestcase.cpp
@@ -19,6 +19,14 @@ ReactTestCase::ReactTestCase(QObject* parent) : QObject(parent) {
 void ReactTestCase::initTestCase() {
     m_quickView = new QQuickView();
     utilities::registerReactTypes();
+
+    clickDelayTimer = new QTimer(this);
+    clickDelayTimer->setSingleShot(true);
+    clickDelayTimer->setInterval(CLICK_TIMER_DELAY);
+
+    initDelayTimer = new QTimer(this);
+    initDelayTimer->setSingleShot(true);
+    initDelayTimer->setInterval(INIT_TIMER_DELAY);
 }
 
 void ReactTestCase::cleanupTestCase() {
@@ -26,6 +34,15 @@ void ReactTestCase::cleanupTestCase() {
         m_quickView->deleteLater();
         m_quickView = nullptr;
     }
+}
+
+void ReactTestCase::init() {
+    initDelayTimer->start();
+    waitAndVerifyCondition([=]() { return !initDelayTimer->isActive(); }, "Timer timeout was not triggered");
+}
+
+void ReactTestCase::cleanup() {
+    bridge()->reset();
 }
 
 void ReactTestCase::loadQML(const QUrl& qmlUrl) {

--- a/ReactQt/tests/reacttestcase.h
+++ b/ReactQt/tests/reacttestcase.h
@@ -20,6 +20,16 @@ class Bridge;
         BaseClass::cleanupTestCase();                                                                                  \
     }
 
+#define INIT_DEFAULT(BaseClass)                                                                                        \
+    virtual void init() override {                                                                                     \
+        BaseClass::init();                                                                                             \
+    }
+
+#define CLEANUP_DEFAULT(BaseClass)                                                                                     \
+    virtual void cleanup() override {                                                                                  \
+        BaseClass::cleanup();                                                                                          \
+    }
+
 class ReactTestCase : public QObject {
     Q_OBJECT
 public:
@@ -44,6 +54,8 @@ protected:
     QQuickItem* topJSComponent() const;
     QVariant valueOfControlProperty(QQuickItem* control, const QString& propertyName);
     void clickItem(QQuickItem* item);
+    virtual void init();
+    virtual void cleanup();
 
 private:
     void registerReactQtTypes();
@@ -51,6 +63,13 @@ private:
 private:
     QQuickView* m_quickView = nullptr;
     QTimer timeoutTimer;
+
+protected:
+    QTimer* clickDelayTimer = nullptr;
+    QTimer* initDelayTimer = nullptr;
+
+    const int CLICK_TIMER_DELAY = 1000;
+    const int INIT_TIMER_DELAY = 4000;
 };
 
 #endif // REACTTESTCASE_H

--- a/ReactQt/tests/test-activityindicator-props.cpp
+++ b/ReactQt/tests/test-activityindicator-props.cpp
@@ -57,6 +57,7 @@ void TestActivityIndicatorProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestActivityIndicatorProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestActivityIndicatorProps::propValues() const {

--- a/ReactQt/tests/test-array-reconciliation.cpp
+++ b/ReactQt/tests/test-array-reconciliation.cpp
@@ -22,20 +22,18 @@ class TestArrayReconciliation : public ReactTestCase {
 
 private slots:
     virtual void initTestCase() override;
-    void init();
-    void cleanup();
     CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+    CLEANUP_DEFAULT(ReactTestCase)
+    INIT_DEFAULT(ReactTestCase)
 
     void testComponentsArrayFirstElementInsert();
     void testComponentsArrayLastElementDelete();
     void testComponentsArrayItemMove();
 
 private:
-    QTimer* clickDelayTimer = nullptr;
     QQuickItem* topView = nullptr;
     const int INITIAL_ITEMS_COUNT = 3;
     const int CLICKED_ITEMS_COUNT = 2;
-    const int CLICK_TIMER_DELAY = 1000;
 
     void validateComponentsCount(const int expectedItemsCount, const QString& errorMsg);
 };
@@ -43,24 +41,9 @@ private:
 void TestArrayReconciliation::initTestCase() {
     ReactTestCase::initTestCase();
 
-    clickDelayTimer = new QTimer(this);
-    clickDelayTimer->setSingleShot(true);
-    clickDelayTimer->setInterval(CLICK_TIMER_DELAY);
-
     loadQML(QUrl("qrc:/TestArrayReconciliation.qml"));
     waitAndVerifyJsAppStarted();
     showView();
-}
-
-void TestArrayReconciliation::init() {
-    clickDelayTimer->setInterval(4000);
-    clickDelayTimer->start();
-    waitAndVerifyCondition([=]() { return !clickDelayTimer->isActive(); }, "Timer timeout was not triggered");
-    clickDelayTimer->setInterval(CLICK_TIMER_DELAY);
-}
-
-void TestArrayReconciliation::cleanup() {
-    bridge()->reset();
 }
 
 void TestArrayReconciliation::validateComponentsCount(const int expectedItemsCount, const QString& errorMsg) {

--- a/ReactQt/tests/test-button-props.cpp
+++ b/ReactQt/tests/test-button-props.cpp
@@ -37,6 +37,7 @@ void TestButtonProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestButtonProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestButtonProps::propValues() const {

--- a/ReactQt/tests/test-button-size.cpp
+++ b/ReactQt/tests/test-button-size.cpp
@@ -25,6 +25,8 @@ private slots:
 
     virtual void initTestCase() override;
     CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+    CLEANUP_DEFAULT(ReactTestCase)
+    INIT_DEFAULT(ReactTestCase)
 
     void testButtonShouldBeVisible();
 };

--- a/ReactQt/tests/test-image-props.cpp
+++ b/ReactQt/tests/test-image-props.cpp
@@ -37,6 +37,7 @@ void TestImageProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestImageProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
     // wait when image loaded. otherwise we can get crash if app quites while loading in progress.
     waitAndVerifyCondition([=]() { return valueOfProperty("imageReady").toBool(); }, "Image can't load source");
 }

--- a/ReactQt/tests/test-integration.cpp
+++ b/ReactQt/tests/test-integration.cpp
@@ -24,6 +24,8 @@ class TestIntegration : public ReactTestCase {
 private slots:
     INIT_TEST_CASE_DEFAULT(ReactTestCase)
     CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+    CLEANUP_DEFAULT(ReactTestCase)
+    INIT_DEFAULT(ReactTestCase)
 
     void testTestModuleMarkTestCompleted();
     void testJSExceptionReceived();
@@ -44,12 +46,6 @@ void TestIntegration::testTestModuleMarkTestCompleted() {
 }
 
 void TestIntegration::testJSExceptionReceived() {
-    QTimer* startupDelayTimer = new QTimer(this);
-    startupDelayTimer->setSingleShot(true);
-    startupDelayTimer->setInterval(1000);
-    startupDelayTimer->start();
-    waitAndVerifyCondition([=]() { return !startupDelayTimer->isActive(); }, "Timer timeout was not triggered");
-
     loadJSBundle("TestJSException", "IntegrationTests/TestJSException");
 
     waitAndVerifyJsAppStarted();

--- a/ReactQt/tests/test-modal-props.cpp
+++ b/ReactQt/tests/test-modal-props.cpp
@@ -34,6 +34,7 @@ void TestModalProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestModalProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestModalProps::propValues() const {

--- a/ReactQt/tests/test-picker-props.cpp
+++ b/ReactQt/tests/test-picker-props.cpp
@@ -34,6 +34,7 @@ void TestPickerProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestPickerProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestPickerProps::propValues() const {

--- a/ReactQt/tests/test-slider-props.cpp
+++ b/ReactQt/tests/test-slider-props.cpp
@@ -34,6 +34,7 @@ void TestSliderProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestSliderProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestSliderProps::propValues() const {

--- a/ReactQt/tests/test-textinput-clear.cpp
+++ b/ReactQt/tests/test-textinput-clear.cpp
@@ -25,6 +25,8 @@ private slots:
 
     virtual void initTestCase() override;
     CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+    CLEANUP_DEFAULT(ReactTestCase)
+    INIT_DEFAULT(ReactTestCase)
 
     void testTextEmptyAfterClear();
 };

--- a/ReactQt/tests/test-textinput-props.cpp
+++ b/ReactQt/tests/test-textinput-props.cpp
@@ -34,6 +34,7 @@ void TestTextInputProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
     loadQML(QUrl("qrc:/TestTextInputProps.qml"));
     waitAndVerifyJsAppStarted();
+    ReactPropertyTestCase::init();
 }
 
 QVariantMap TestTextInputProps::propValues() const {


### PR DESCRIPTION
Closes https://github.com/status-im/react-native-desktop/issues/303

Executor and Connection instances are moved to separate QThread.

`invokeModuleMethod` call happens back in main thread, since it calls native modules created on main thread and should be executed on main thread because of this.

Inter-thread communication happens via QMetaObject::invokeMethod with Qt::AutoConnection to post the call into the event loop of invoked object's thread automatically.

Testing notes for status-react Desktop:

Application should operate as usual: Login, Contact adding, send a message, etc.
