### PR TITLE
Add custom fonts to the desktop apps

### DIFF
--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -21,6 +21,8 @@ if (USE_QTWEBKIT)
   find_package(Qt5WebKit REQUIRED)
 endif()
 
+MESSAGE( STATUS "Desktop fonts var: " ${DESKTOP_FONTS} )
+
 # Format EXTERNAL_MODULES to contain array of external modules type names defined as strings
 string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}")
 
@@ -63,5 +65,3 @@ target_link_libraries(
   ${APP_NAME}
   react-native
 )
-
-

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+set(FONTS_RESOURCE "")
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Qml REQUIRED)
@@ -21,7 +22,14 @@ if (USE_QTWEBKIT)
   find_package(Qt5WebKit REQUIRED)
 endif()
 
-MESSAGE( STATUS "Desktop fonts var: " ${DESKTOP_FONTS} )
+# Add all external desktop fonts to resources. Fonts will be outside of directory with qrc,
+# so we are using aliases to load them
+foreach(FONT_PATH ${DESKTOP_FONTS})
+    get_filename_component(FONT_FILENAME ${FONT_PATH} NAME)
+    STRING(CONCAT TMP ${FONTS_RESOURCE} "<file alias=\"${FONT_FILENAME}\">${FONT_PATH}</file>")
+    SET(FONTS_RESOURCE ${TMP})
+endforeach(FONT_PATH)
+
 
 # Format EXTERNAL_MODULES to contain array of external modules type names defined as strings
 string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}")

--- a/ReactQt/application/src/main.cpp
+++ b/ReactQt/application/src/main.cpp
@@ -12,6 +12,8 @@
 #include <QGuiApplication>
 #include <QQuickView>
 #include <QUrl>
+#include <QFontDatabase>
+#include <QDirIterator>
 
 #include "attachedproperties.h"
 #include "reactitem.h"
@@ -117,10 +119,24 @@ private:
     QString m_executor = "LocalServerConnection";
 };
 
+void loadFontsFromResources() {
+
+    QDirIterator it(":", QDirIterator::Subdirectories);
+    while (it.hasNext()) {
+      QString resourceFile = it.next();
+      if(resourceFile.endsWith(".otf", Qt::CaseInsensitive) ||
+         resourceFile.endsWith(".ttf", Qt::CaseInsensitive)) {
+          QFontDatabase::addApplicationFont(resourceFile);
+      }
+    }
+}
+
 int main(int argc, char** argv) {
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
     Q_INIT_RESOURCE(react_resources);
+
+    loadFontsFromResources();
 
     QQuickView view;
     ReactNativeProperties* rnp = new ReactNativeProperties(&view);

--- a/ReactQt/application/src/main.qrc.in
+++ b/ReactQt/application/src/main.qrc.in
@@ -12,5 +12,6 @@
   <qresource>
     <file>main.qml</file>
     ${JS_BUNDLE_RESOURCE}
+    ${FONTS_RESOURCE}
   </qresource>
 </RCC>

--- a/local-cli/desktop/build.js
+++ b/local-cli/desktop/build.js
@@ -24,6 +24,9 @@ function build(args, dependencies) {
   console.log("Found desktop external modules: " + desktopExternalModules);
   var desktopJSBundlePath = _findDesktopJSBundlePath(args);
   console.log("Found desktop JS bundle path: " + desktopJSBundlePath);
+  var desktopFonts = _findDesktopFonts(args);
+  console.log("Found desktop fonts: " + desktopFonts);
+
   return _findModules(args).then((dependencies) => {
     return new Promise((resolve, reject) => {
       _findDesktopModules(args, dependencies, resolve, reject);
@@ -37,7 +40,7 @@ function build(args, dependencies) {
       }
     });
   }).then(() => {
-    return _buildApplication(args, desktopExternalModules, desktopJSBundlePath);
+    return _buildApplication(args, desktopExternalModules, desktopJSBundlePath, desktopFonts);
   });
 }
 
@@ -49,6 +52,11 @@ function _findDesktopExternalModules(args) {
 function _findDesktopJSBundlePath(args) {
   var data = fs.readFileSync(path.join(args.root, 'package.json'));
   return JSON.parse(data).desktopJSBundlePath;
+}
+
+function _findDesktopFonts(args) {
+  var data = fs.readFileSync(path.join(args.root, 'package.json'));
+  return JSON.parse(data).desktopFonts;
 }
 
 function _findModules(args) {
@@ -113,7 +121,7 @@ function _buildModules(args, dependencies, resolve, reject) {
   });
 }
 
-function _buildApplication(args, desktopExternalModules, desktopJSBundlePath) {
+function _buildApplication(args, desktopExternalModules, desktopJSBundlePath, desktopFonts) {
   return new Promise((resolve, reject) => {
     console.log(chalk.bold('Building the app...'));
 
@@ -123,6 +131,9 @@ function _buildApplication(args, desktopExternalModules, desktopJSBundlePath) {
     }
     if (typeof desktopJSBundlePath !== 'undefined' && desktopJSBundlePath !== null) {
       buildCommand += ' -j "' + desktopJSBundlePath.toString() + '"';
+    }
+    if (typeof desktopFonts !== 'undefined' && desktopFonts !== null) {
+      buildCommand += ' -f "' + desktopFonts.toString().replace(/,/g, ';') + '"';
     }
     if (process.platform === "win32") {
       buildCommand += ' -g "' + "MinGW Makefiles" + '"';

--- a/local-cli/generator-desktop/templates/build.bat
+++ b/local-cli/generator-desktop/templates/build.bat
@@ -3,7 +3,7 @@
 @rem
 @rem This source code is licensed under the BSD-style license found in the
 @rem LICENSE file in the root directory of this source tree. An additional grant
-@rem of patent rights can be found in the PATENTS file in the same directory. 
+@rem of patent rights can be found in the PATENTS file in the same directory.
 
 @echo off
 setlocal EnableDelayedExpansion
@@ -24,6 +24,7 @@ SET option
 
 echo "build.bat external modules paths: "%option-e%
 echo "build.bat JS bundle path: "%option-j%
+echo "build.bat desktop fonts: "%option-f%
 echo "build.bat cmake generator: "%option-g%
 
 @rem Workaround
@@ -31,4 +32,4 @@ echo "build.bat cmake generator: "%option-g%
 
 @rem Build project
 echo %CD%
-cmake -DCMAKE_BUILD_TYPE=Debug -G %option-g% -DEXTERNAL_MODULES_DIR=%option-e% -DJS_BUNDLE_PATH=%option-j% . && cmake --build .
+cmake -DCMAKE_BUILD_TYPE=Debug -G %option-g% -DEXTERNAL_MODULES_DIR=%option-e% -DJS_BUNDLE_PATH=%option-j% -DDESKTOP_FONTS=%option-f% . && cmake --build .

--- a/local-cli/generator-desktop/templates/build.sh
+++ b/local-cli/generator-desktop/templates/build.sh
@@ -19,14 +19,19 @@ if [[ $1 == "-j" ]]; then
   shift
 	JsBundlePath="$1"
 fi
+if [[ $1 == "-f" ]]; then
+  shift
+	desktopFonts="$1"
+fi
 shift
 done
 
 echo "build.sh external modules paths: "$ExternalModulesPaths
 echo "build.sh JS bundle path: "$JsBundlePath
+echo "build.sh desktop fonts: "$desktopFonts
 
 # Workaround
 rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile
 
 # Build project
-cmake -DCMAKE_BUILD_TYPE=Debug -DEXTERNAL_MODULES_DIR="$ExternalModulesPaths" -DJS_BUNDLE_PATH="$JsBundlePath" . && make
+cmake -DCMAKE_BUILD_TYPE=Debug -DEXTERNAL_MODULES_DIR="$ExternalModulesPaths" -DJS_BUNDLE_PATH="$JsBundlePath" -DDESKTOP_FONTS="$desktopFonts" . && make


### PR DESCRIPTION
### Description

Added possibility to mention list of used fonts in a `package.json` and they will be loaded on app start.
Related to https://github.com/status-im/status-react/issues/4860

### Steps to test
1) create new app: `react-native init TestFontsDesktop --version status-im/react-native-desktop#feature/custom_fonts`
2) Unzip attached fonts folder ([assets.zip](https://github.com/status-im/react-native-desktop/files/2267751/assets.zip)) inside `TestFontsDesktop`
3) Edit package.json, add following code:
```
"desktopFonts": [
    "../../../../../assets/fonts/SF-Pro-Text-Regular.otf",
    "../../../../../assets/fonts/SF-Pro-Text-Medium.otf",
    "../../../../../assets/fonts/SF-Pro-Text-Light.otf"
  ],
```
Please note, path to fonts is written in relation to `main.qrc` which is in `TestFontsDesktop/node_modules/react-native/ReactQt/application/src/`.

4) in default `index.desktop.js` change text component styles to use newly added fonts:
```
welcome: {
    fontSize: 20,
    textAlign: 'center',
    margin: 10,
    fontFamily: "SFProText-Light"
  },
  instructions: {
    fontSize: 20,
    textAlign: 'center',
    color: '#333333',
    marginBottom: 5,
    fontFamily: "SFProText-Medium"
  },
```

### Notes
To get information about font, `fc-scan` command can be used: `fc-scan SF-Pro-Text-Light.otf`
Among the info you can found `family` and `postscriptname` properties.
The main problem with this feature implementation was the following. `react-native` Text component uses `postscriptname` of the font to reference it, for example: "SFProText-Medium". But Qt, when loads font, gives you access only to a family name. And family name will be the same for `SF-Pro-Text-Light.otf`, `SF-Pro-Text-Medium.otf`, etc... it will be `SF Pro Text`. 
After spending quite  a lot of time in attempts to get over this bug, I finally decided to use workaround. I simply changed family property for the fonts that you will find in attached archive. To make them distinguishable in Qt.  (used tool FontLab).

All that means that you can't successfully use few font files that are belong to the same family until you change them to have different families.


