### PR TITLE
ScrollView content rendering optimization

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -493,6 +493,23 @@ const ScrollView = createReactClass({
        // Opaque type returned by import IMAGE from './image.jpg'
        PropTypes.number,
      ]),
+    /**
+     * Enables rendering optimization for content's items arrays inside scroll view
+     * @platform desktop
+     */
+     enableArrayScrollingOptimization: PropTypes.bool,
+    /**
+     * Scroll view content top padding.
+     * `enableArrayScrollingOptimization` prop should be enabled.
+     * @platform desktop
+     */
+     headerHeight: PropTypes.number,
+    /**
+     * Scroll view content bottom padding.
+     * `enableArrayScrollingOptimization` prop should be enabled.
+     * @platform desktop
+     */
+     footerWidth: PropTypes.number,
   },
 
   getDefaultProps: function() : any {
@@ -902,14 +919,25 @@ const ScrollView = createReactClass({
         );
       }
     }
-    return (
-      /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
-       * comment suppresses an error when upgrading Flow's support for React.
-       * To see the error delete this comment and run Flow. */
-      <ScrollViewClass {...props} ref={this._setScrollViewRef}>
-        {contentContainer}
-      </ScrollViewClass>
-    );
+    if (Platform.OS === 'desktop' && props.enableArrayScrollingOptimization) {
+        return (
+          /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
+           * comment suppresses an error when upgrading Flow's support for React.
+           * To see the error delete this comment and run Flow. */
+          <ScrollViewClass {...props} {...contentSizeChangeProps} ref={this._setScrollViewRef}>
+            {children}
+          </ScrollViewClass>
+        );
+    } else {
+        return (
+          /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
+           * comment suppresses an error when upgrading Flow's support for React.
+           * To see the error delete this comment and run Flow. */
+          <ScrollViewClass {...props} ref={this._setScrollViewRef}>
+            {contentContainer}
+          </ScrollViewClass>
+        );
+    }
   }
 });
 

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -175,6 +175,7 @@ set(
   qml/ReactView.qml
   qml/ReactNavigator.qml
   qml/ReactScrollView.qml
+  qml/ReactScrollListView.qml
   qml/ReactRedboxItem.qml
   qml/ReactText.qml
   qml/ReactRawText.qml

--- a/ReactQt/runtime/src/componentmanagers/activityindicatormanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/activityindicatormanager.cpp
@@ -38,7 +38,7 @@ QString ActivityIndicatorManager::moduleName() {
     return "RCTActivityIndicatorViewManager";
 }
 
-QString ActivityIndicatorManager::qmlComponentFile() const {
+QString ActivityIndicatorManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactActivityIndicator.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/activityindicatormanager.h
+++ b/ReactQt/runtime/src/componentmanagers/activityindicatormanager.h
@@ -29,7 +29,7 @@ public:
     virtual QString moduleName() override;
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
 
 private:
     QScopedPointer<ActivityIndicatorManagerPrivate> d_ptr;

--- a/ReactQt/runtime/src/componentmanagers/buttonmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/buttonmanager.cpp
@@ -73,7 +73,7 @@ void ButtonManager::sendPressedNotificationToJs(QQuickItem* button) {
     notifyJsAboutEvent(tag(button), EVENT_ONPRESSED, {});
 }
 
-QString ButtonManager::qmlComponentFile() const {
+QString ButtonManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactButton.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/buttonmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/buttonmanager.h
@@ -33,7 +33,7 @@ public slots:
     void sendPressedNotificationToJs(QQuickItem* button);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* button) const override;
 
 private:

--- a/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
@@ -36,7 +36,7 @@ static QMap<ImageLoader::Event, QString> eventNames{{ImageLoader::Event_LoadStar
                                                     {ImageLoader::Event_LoadEnd, "onLoadEnd"}};
 const QString URI_KEY = QStringLiteral("uri");
 const QString FILE_SCHEME = QStringLiteral("file://");
-}
+} // namespace
 
 class ImageManagerPrivate {
 
@@ -103,7 +103,7 @@ void ImageManager::configureView(QQuickItem* view) const {
     view->setEnabled(false);
 }
 
-QString ImageManager::qmlComponentFile() const {
+QString ImageManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactImage.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/imagemanager.h
+++ b/ReactQt/runtime/src/componentmanagers/imagemanager.h
@@ -37,7 +37,7 @@ public slots:
 
 private:
     virtual void configureView(QQuickItem* view) const override;
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
 
 private:
     QScopedPointer<ImageManagerPrivate> d_ptr;

--- a/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
@@ -70,7 +70,7 @@ void ModalManager::configureView(QQuickItem* modal) const {
     modal->setProperty("modalManager", QVariant::fromValue((QObject*)this));
 }
 
-QString ModalManager::qmlComponentFile() const {
+QString ModalManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactModal.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/modalmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/modalmanager.h
@@ -36,7 +36,7 @@ public slots:
     void sendOnShowNotificationToJs(QQuickItem* modal);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* modal) const override;
 
 private:

--- a/ReactQt/runtime/src/componentmanagers/navigatormanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/navigatormanager.cpp
@@ -87,7 +87,7 @@ void NavigatorManager::configureView(QQuickItem* view) const {
     connect(view, SIGNAL(backTriggered()), SLOT(backTriggered()));
 }
 
-QString NavigatorManager::qmlComponentFile() const {
+QString NavigatorManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactNavigator.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/navigatormanager.h
+++ b/ReactQt/runtime/src/componentmanagers/navigatormanager.h
@@ -44,7 +44,7 @@ private Q_SLOTS:
 
 private:
     virtual void configureView(QQuickItem* view) const override;
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
 
     void invokeMethod(const QString& methodSignature, QQuickItem* item, const QVariantList& args = QVariantList{});
     QMetaMethod findMethod(const QString& methodSignature, QQuickItem* item);

--- a/ReactQt/runtime/src/componentmanagers/pickermanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/pickermanager.cpp
@@ -39,7 +39,7 @@ QString PickerManager::moduleName() {
     return "RCTPickerViewManager";
 }
 
-QString PickerManager::qmlComponentFile() const {
+QString PickerManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactPicker.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/pickermanager.h
+++ b/ReactQt/runtime/src/componentmanagers/pickermanager.h
@@ -35,7 +35,7 @@ public slots:
     void sendValueChangeToJs(QQuickItem* picker, int index);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
 
 private:

--- a/ReactQt/runtime/src/componentmanagers/rawtextmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/rawtextmanager.cpp
@@ -42,6 +42,6 @@ void RawTextManager::configureView(QQuickItem* view) const {
     view->setEnabled(false);
 }
 
-QString RawTextManager::qmlComponentFile() const {
+QString RawTextManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactRawText.qml";
 }

--- a/ReactQt/runtime/src/componentmanagers/rawtextmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/rawtextmanager.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     virtual void configureView(QQuickItem* view) const override;
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
 };
 
 #endif // RAWTEXTMANAGER_H

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -37,6 +37,12 @@ public:
 
     void addChildItem(QQuickItem* scrollView, QQuickItem* child, int position) const override;
 
+    static bool isArrayScrollingOptimizationEnabled(QQuickItem* item);
+    static void updateListViewItem(QQuickItem* item, QQuickItem* child, int position);
+    static void
+    removeListViewItem(QQuickItem* item, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
+    static QQuickItem* scrollViewContentItem(QQuickItem* item, int position);
+
 private Q_SLOTS:
     void scrollBeginDrag();
     void scrollEndDrag();
@@ -48,7 +54,11 @@ private Q_SLOTS:
 private:
     QVariantMap buildEventData(QQuickItem* item) const;
     virtual void configureView(QQuickItem* view) const override;
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
+    bool arrayScrollingOptimizationEnabled(QQuickItem* item) const;
+
+    static QMap<QQuickItem*, QQuickItem*> m_scrollViewByListViewItem;
+    static QMap<QQuickItem*, QVariantList> m_modelByScrollView;
 };
 
 #endif // SCROLLVIEWMANAGER_H

--- a/ReactQt/runtime/src/componentmanagers/slidermanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/slidermanager.cpp
@@ -49,6 +49,7 @@ QString SliderManager::moduleName() {
 QStringList SliderManager::customDirectEventTypes() {
     return QStringList{
         normalizeInputEventName(EVENT_ON_VALUE_CHANGED), normalizeInputEventName(EVENT_ON_SLIDING_COMPLETE),
+
     };
 }
 
@@ -64,7 +65,7 @@ void SliderManager::sendSlidingCompleteToJs(QQuickItem* slider) {
     notifyJsAboutSliderEvent(slider, EVENT_ON_SLIDING_COMPLETE);
 }
 
-QString SliderManager::qmlComponentFile() const {
+QString SliderManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactSlider.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/slidermanager.h
+++ b/ReactQt/runtime/src/componentmanagers/slidermanager.h
@@ -33,7 +33,7 @@ public slots:
     void sendSlidingCompleteToJs(QQuickItem* slider);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
 
     void notifyJsAboutSliderEvent(QQuickItem* slider, const QString& eventName) const;

--- a/ReactQt/runtime/src/componentmanagers/switchmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/switchmanager.cpp
@@ -40,7 +40,7 @@ QString SwitchManager::moduleName() {
     return "RCTSwitchManager";
 }
 
-QString SwitchManager::qmlComponentFile() const {
+QString SwitchManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactSwitch.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/switchmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/switchmanager.h
@@ -35,7 +35,7 @@ public slots:
     void sendValueChangeToJs(QQuickItem* picker, bool value);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
     void updateMeasureFunction(QQuickItem* view) const;
 

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -47,7 +47,7 @@ QString TextInputManager::moduleName() {
     return "RCTTextInputViewManager";
 }
 
-QString TextInputManager::qmlComponentFile() const {
+QString TextInputManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactTextInput.qml";
 }
 

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.h
@@ -40,7 +40,7 @@ public slots:
     void sendOnContentSizeChange(QQuickItem* textInput, double width, double height);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
 
     void sendTextInputEvent(QQuickItem* textInput, QString eventName, QVariantMap additionalEventData = QVariantMap());

--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -51,7 +51,7 @@ bool TextManager::shouldLayout() const {
     return true;
 }
 
-QString TextManager::qmlComponentFile() const {
+QString TextManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactText.qml";
 }
 
@@ -71,7 +71,6 @@ void TextManager::updateMeasureFunction(QQuickItem* textItem) {
 
     if (childIsTopReactTextInTextHierarchy) {
         flexbox->setMeasureFunction([=](YGNodeRef, float width, YGMeasureMode, float, YGMeasureMode) {
-
             resizeToWidth(textItem, width);
             float w = textItem->width();
             float ch = textItem->property("contentHeight").toDouble();

--- a/ReactQt/runtime/src/componentmanagers/textmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.h
@@ -45,7 +45,7 @@ private:
     QQuickItem* parentTextItem(QQuickItem* textItem);
     bool propertyExplicitlySet(QQuickItem* item, const QString& propertyName);
 
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
 
 private:

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -80,7 +80,8 @@ void ViewManager::addChildItem(QQuickItem* container, QQuickItem* child, int pos
 }
 
 QQuickItem* ViewManager::view(const QVariantMap& properties) const {
-    QQuickItem* newView = createView();
+    qDebug() << "!!!! ViewManager::view props: " << properties;
+    QQuickItem* newView = createView(properties);
     if (newView) {
         configureView(newView);
     }
@@ -91,7 +92,7 @@ void ViewManager::configureView(QQuickItem* view) const {
     view->setProperty("viewManager", QVariant::fromValue((QObject*)this));
 }
 
-QString ViewManager::qmlComponentFile() const {
+QString ViewManager::qmlComponentFile(const QVariantMap& properties) const {
     return "qrc:/qml/ReactView.qml";
 }
 
@@ -114,15 +115,18 @@ void ViewManager::sendOnLayoutToJs(QQuickItem* view, float x, float y, float wid
     if (!view)
         return;
 
+    qDebug() << " call of ViewManager::sendOnLayoutToJs for " << view;
+
     notifyJsAboutEvent(tag(view),
                        EVENT_ONLAYOUT,
                        QVariantMap{{"layout", QVariantMap{{"x", x}, {"y", y}, {"width", width}, {"height", height}}}});
 }
 
-QQuickItem* ViewManager::createView() const {
-    QQuickItem* item = createQMLItemFromSourceFile(m_bridge->qmlEngine(), QUrl(qmlComponentFile()));
+QQuickItem* ViewManager::createView(const QVariantMap& properties) const {
+    qDebug() << "!!!! ViewManager::createView props: " << properties;
+    QQuickItem* item = createQMLItemFromSourceFile(m_bridge->qmlEngine(), QUrl(qmlComponentFile(properties)));
     if (item == nullptr) {
-        qCritical() << QString("Can't create QML item for componenet %1").arg(qmlComponentFile());
+        qCritical() << QString("Can't create QML item for componenet %1").arg(qmlComponentFile(properties));
     }
     return item;
 }

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.h
@@ -50,10 +50,10 @@ public:
     Q_INVOKABLE void sendOnLayoutToJs(QQuickItem* view, float x, float y, float width, float height);
 
 protected:
-    QQuickItem* createView() const;
+    QQuickItem* createView(const QVariantMap& properties) const;
     Bridge* bridge() const;
     virtual void configureView(QQuickItem* view) const;
-    virtual QString qmlComponentFile() const;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const;
     void notifyJsAboutEvent(int senderTag, const QString& eventName, const QVariantMap& eventData) const;
 
 private:

--- a/ReactQt/runtime/src/componentmanagers/webviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/webviewmanager.cpp
@@ -23,7 +23,6 @@
 #include "modulemethod.h"
 #include "propertyhandler.h"
 #include "utilities.h"
-#include "utilities.h"
 #include "webviewmanager.h"
 
 const QString EVENT_ONERROR = "onLoadingError";
@@ -44,7 +43,7 @@ QString WebViewManager::moduleName() {
     return "RCTWebViewViewManager";
 }
 
-QString WebViewManager::qmlComponentFile() const {
+QString WebViewManager::qmlComponentFile(const QVariantMap& properties) const {
 #ifdef USE_QTWEBKIT
     const QString reactWebViewComponent = QStringLiteral("qrc:/qml/ReactQtWebKitWebView.qml");
 #else

--- a/ReactQt/runtime/src/componentmanagers/webviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/webviewmanager.h
@@ -48,7 +48,7 @@ public slots:
     void sendOnErrorNotificationToJs(QQuickItem* webView);
 
 private:
-    virtual QString qmlComponentFile() const override;
+    virtual QString qmlComponentFile(const QVariantMap& properties) const override;
     virtual void configureView(QQuickItem* view) const override;
 
 private:

--- a/ReactQt/runtime/src/qml/ReactScrollListView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollListView.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.2
+import React 0.1 as React
+
+ListView{
+    id: scrollViewRoot
+
+    property var scrollViewManager: null
+    property bool p_onScroll: false
+    property var flexbox: React.Flexbox {control: scrollViewRoot; viewManager: scrollViewManager}
+    property bool p_enableArrayScrollingOptimization: false
+    property int p_headerHeight: 0
+    property int p_footerWidth: 0
+
+    clip: true
+    contentHeight: contentItem.childrenRect.height
+    contentWidth: contentItem.childrenRect.width
+
+    onCountChanged: {
+        if(scrollViewManager)
+            scrollViewManager.sendOnLayoutToJs(scrollViewRoot, contentX, contentY, contentWidth, contentHeight);
+    }
+
+    header: Item {
+        height: p_headerHeight
+    }
+    footer: Item {
+        height: p_footerWidth
+    }
+
+    delegate: Item {
+        id: componentId
+        height: modelData.height
+        width: modelData.width
+        Component.onCompleted: {
+            modelData.parent = componentId
+            modelData.anchors.centerIn = componentId
+        }
+
+        Component.onDestruction: {
+            modelData.parent = null
+        }
+    }
+}

--- a/ReactQt/runtime/src/qml/ReactScrollView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollView.qml
@@ -7,6 +7,9 @@ Flickable {
 
     property bool p_onScroll: false
     property var flexbox: React.Flexbox {control: scrollViewRoot}
+    property bool p_enableArrayScrollingOptimization: false
+    property int p_headerHeight: 0
+    property int p_footerWidth: 0
 
     clip: true
     contentHeight: contentItem.childrenRect.height

--- a/ReactQt/runtime/src/react_resources.qrc
+++ b/ReactQt/runtime/src/react_resources.qrc
@@ -5,6 +5,7 @@
         <file>qml/ReactView.qml</file>
         <file>qml/ReactNavigator.qml</file>
         <file>qml/ReactScrollView.qml</file>
+        <file>qml/ReactScrollListView.qml</file>
         <file>qml/ReactRedboxItem.qml</file>
         <file>qml/ReactRawText.qml</file>
         <file>qml/ReactText.qml</file>


### PR DESCRIPTION
**Issue description:**

ScrollView keeps all children views visible in scene graph and ui experiences responsiveness issues on huge amount of visual items. 

**Changes description:**

Changes in PR introduces new props into ScrollView.js component:

```
     /**
     * Enables rendering optimization for content's items arrays inside scroll view
     * @platform desktop
     */
     enableArrayScrollingOptimization: PropTypes.bool,
    /**
     * Scroll view content top padding.
     * `enableArrayScrollingOptimization` prop should be enabled.
     * @platform desktop
     */
     headerHeight: PropTypes.number,
    /**
     * Scroll view content bottom padding.
     * `enableArrayScrollingOptimization` prop should be enabled.
     * @platform desktop
     */
     footerWidth: PropTypes.number,
```

When `enableArrayScrollingOptimization` is set to `true`, ScrollViewManager expects direct child of ScrollView to be defined as array of elements. Newly introduced ReactScrollListView.qmll is ListView qml component based. ListView takes the model of pre-created QQuickItem views of array's elements and mount/unmount them dynamically into scene graph (this happens in ListView's delegate component). Additionally, with `headerHeight` and `footerWidth` props its possible to set top and bottom padding for elements in ListView.




