### PR TITLE
Fixed layout recalculation for text

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -70,11 +70,13 @@ void TextManager::updateMeasureFunction(QQuickItem* textItem) {
     bool childIsTopReactTextInTextHierarchy = textItem->property("textIsTopInBlock").toBool();
 
     if (childIsTopReactTextInTextHierarchy) {
-        flexbox->setMeasureFunction([=](YGNodeRef, float width, YGMeasureMode, float, YGMeasureMode) {
+        flexbox->setMeasureFunction([=](
+            YGNodeRef /*node*/, float width, YGMeasureMode /*widthMode*/, float height, YGMeasureMode /*heightMode*/) {
             resizeToWidth(textItem, width);
+            resizeToHeight(textItem, height);
+            float h = textItem->height();
             float w = textItem->width();
-            float ch = textItem->property("contentHeight").toDouble();
-            return YGSize{w, ch};
+            return YGSize{w, h};
         });
     } else {
         flexbox->setMeasureFunction(nullptr);
@@ -82,6 +84,7 @@ void TextManager::updateMeasureFunction(QQuickItem* textItem) {
 }
 
 void TextManager::resizeToWidth(QQuickItem* textItem, double width) {
+    textItem->setWidth(width);
     double contentWidth = textItem->property("contentWidth").value<double>();
     double sw = 0;
     if (std::isnan(width)) {
@@ -90,6 +93,18 @@ void TextManager::resizeToWidth(QQuickItem* textItem, double width) {
         sw = contentWidth == 0 ? width : qMin(contentWidth, width);
     }
     textItem->setWidth(sw);
+}
+
+void TextManager::resizeToHeight(QQuickItem* textItem, double height) {
+    textItem->setHeight(height);
+    double contentHeight = textItem->property("contentHeight").value<double>();
+    double sh = 0;
+    if (std::isnan(height)) {
+        sh = contentHeight;
+    } else {
+        sh = contentHeight == 0 ? height : qMin(contentHeight, height);
+    }
+    textItem->setHeight(sh);
 }
 
 QVariant TextManager::nestedPropertyValue(QQuickItem* item, const QString& propertyName) {

--- a/ReactQt/runtime/src/componentmanagers/textmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.h
@@ -36,6 +36,7 @@ public:
 
     typedef std::map<QString, QVariant> PropertyMap;
     static void resizeToWidth(QQuickItem* textItem, double width);
+    static void resizeToHeight(QQuickItem* textItem, double height);
 
 public slots:
     QVariant nestedPropertyValue(QQuickItem* item, const QString& propertyName);

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -80,7 +80,6 @@ void ViewManager::addChildItem(QQuickItem* container, QQuickItem* child, int pos
 }
 
 QQuickItem* ViewManager::view(const QVariantMap& properties) const {
-    qDebug() << "!!!! ViewManager::view props: " << properties;
     QQuickItem* newView = createView(properties);
     if (newView) {
         configureView(newView);
@@ -115,15 +114,12 @@ void ViewManager::sendOnLayoutToJs(QQuickItem* view, float x, float y, float wid
     if (!view)
         return;
 
-    qDebug() << " call of ViewManager::sendOnLayoutToJs for " << view;
-
     notifyJsAboutEvent(tag(view),
                        EVENT_ONLAYOUT,
                        QVariantMap{{"layout", QVariantMap{{"x", x}, {"y", y}, {"width", width}, {"height", height}}}});
 }
 
 QQuickItem* ViewManager::createView(const QVariantMap& properties) const {
-    qDebug() << "!!!! ViewManager::createView props: " << properties;
     QQuickItem* item = createQMLItemFromSourceFile(m_bridge->qmlEngine(), QUrl(qmlComponentFile(properties)));
     if (item == nullptr) {
         qCritical() << QString("Can't create QML item for componenet %1").arg(qmlComponentFile(properties));

--- a/ReactQt/runtime/src/layout/flexbox.cpp
+++ b/ReactQt/runtime/src/layout/flexbox.cpp
@@ -681,6 +681,10 @@ bool Flexbox::isDirty() {
     return YGNodeIsDirty(d_ptr->m_node);
 }
 
+void Flexbox::markDirty() {
+    YGNodeMarkDirty(d_ptr->m_node);
+}
+
 void Flexbox::printFlexboxHierarchy() {
     d_ptr->printNode();
 }

--- a/ReactQt/runtime/src/layout/flexbox.h
+++ b/ReactQt/runtime/src/layout/flexbox.h
@@ -78,7 +78,7 @@ class Flexbox : public QObject {
     Q_PROPERTY(QString p_overflow READ overflow WRITE setOverflow NOTIFY overflowChanged)
     Q_PROPERTY(QString p_position READ position WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(QString p_direction READ direction WRITE setDirection NOTIFY directionChanged)
-    Q_PROPERTY(QString isDirty READ isDirty NOTIFY isDirtyChanged)
+    Q_PROPERTY(bool isDirty READ isDirty NOTIFY isDirtyChanged)
 
 signals:
     void widthChanged();
@@ -234,6 +234,9 @@ public:
     QString direction();
     void setDirection(const QString& value);
     bool isDirty();
+
+public slots:
+    void markDirty();
 
 private:
     QScopedPointer<FlexboxPrivate> d_ptr;

--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -161,6 +161,7 @@ TextEdit {
             }
         }
         decoratedText = htmlString;
+        textRoot.flexbox.markDirty();
     }
 
     function isText(obj)


### PR DESCRIPTION
Now Text component marks its yoga node as "dirty" every time when its content changes.
That forces recalculation of text size.

This will fix issue https://github.com/status-im/status-react/issues/4249
And most probably one more - https://github.com/status-im/status-react/issues/5113
