### PR TITLE
Resolves crash on bridge reload, ReactText.qml error fixture, npm start cache reset

### DIFF
--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -134,6 +134,10 @@ Bridge::Bridge(QObject* parent) : QObject(parent), d_ptr(new BridgePrivate) {
 
 Bridge::~Bridge() {
     resetExecutor();
+    if (d_ptr->executorThread) {
+        d_ptr->executorThread->deleteLater();
+        d_ptr->executorThread = nullptr;
+    }
 }
 
 void* Bridge::getJavaScriptContext() {
@@ -210,11 +214,6 @@ void Bridge::resetExecutor() {
         d->executor->deleteLater();
         d->executor = nullptr;
         d->useJSC = false;
-
-        if (d->executorThread) {
-            d->executorThread->deleteLater();
-            d->executorThread = nullptr;
-        }
     }
 }
 

--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -161,7 +161,9 @@ TextEdit {
             }
         }
         decoratedText = htmlString;
-        textRoot.flexbox.markDirty();
+        if (textRoot.flexbox) {
+            textRoot.flexbox.markDirty();
+        }
     }
 
     function isText(obj)

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "flow": "flow",
     "lint": "eslint .",
     "prettier": "find . -name node_modules -prune -or -name '*.js' -print | xargs prettier --write",
-    "start": "/usr/bin/env bash -c './scripts/packager.sh \"$@\" || true' --",
+    "start": "/usr/bin/env bash -c './scripts/packager.sh \"$@\" --reset-cache || true' --",
     "test-android-setup": "docker pull hramos/android-base:latest",
     "test-android-build-base": "docker build -t hramos/android-base -f ContainerShip/Dockerfile.android-base .",
     "test-android-build": "docker build -t react/android -f ContainerShip/Dockerfile.android .",


### PR DESCRIPTION
- Resolves crash on bridge reload (Executor's thread is not get destroyed on bridge reload anymore);
- Checks flexbox presents for ReactText.qml before markDirty call;
- npm start runs with transform cache reset by default.
