### PR TITLE
Whitespaces not ignored in text

### DIFF
--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -133,7 +133,7 @@ TextEdit {
         var fontStyle = textManager.nestedPropertyValue(textRoot, "p_fontStyle")
         var textDecorLine = textManager.nestedPropertyValue(textRoot, "p_textDecorationLine")
 
-        var result = "<span style=\"" + (fontFamily ? ("font-family:"+fontFamily+";") : "")
+        var result = "<span style=\"white-space: pre; " + (fontFamily ? ("font-family:"+fontFamily+";") : "")
                 + (fontSize? ("font-size:"+fontSize+"pt;") : "")
                 + (color ? ("color:"+color+";") : "")
                 + ( !Qt.colorEqual(backgroundColor, "transparent") ? ("background-color:"+backgroundColor+";") : "")


### PR DESCRIPTION
We use html for displaying Text component. And by default in html few consequent whitespaces shown as one. This PR fixes `Text` component to show exact amount of whitespaces that passed to it.

(in status-react that will fix absence of consequent whitespaces in messages)