### PR TITLE
Disable highlighting in scrollview

### DIFF
--- a/ReactQt/runtime/src/qml/ReactScrollListView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollListView.qml
@@ -15,6 +15,7 @@ ListView{
     clip: true
     contentHeight: contentItem.childrenRect.height
     contentWidth: contentItem.childrenRect.width
+    highlightFollowsCurrentItem: false
 
     onCountChanged: {
         if(scrollViewManager)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-react/issues/5597

Looks like when we don't disable highlightItem, it exists as an invisible element and sometimes doesn't allow us to process the click on an item.