### PR TITLE
ScrollView fixes - momentum events and children finding

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -164,17 +164,13 @@ void ScrollViewManager::scroll() {
     }
 }
 
-void ScrollViewManager::momentumScrollBegin() {
+void ScrollViewManager::momentumScrollBegin(QQuickItem* item) {
     // qDebug() << __PRETTY_FUNCTION__;
-    QQuickItem* item = qobject_cast<QQuickItem*>(sender());
-    Q_ASSERT(item != nullptr);
     notifyJsAboutEvent(tag(item), "momentumScrollBegin", buildEventData(item));
 }
 
-void ScrollViewManager::momentumScrollEnd() {
+void ScrollViewManager::momentumScrollEnd(QQuickItem* item) {
     // qDebug() << __PRETTY_FUNCTION__;
-    QQuickItem* item = qobject_cast<QQuickItem*>(sender());
-    Q_ASSERT(item != nullptr);
     notifyJsAboutEvent(tag(item), "momentumScrollEnd", buildEventData(item));
 }
 
@@ -214,9 +210,6 @@ void ScrollViewManager::configureView(QQuickItem* view) const {
     connect(view, SIGNAL(movementStarted()), SLOT(scrollBeginDrag()));
     connect(view, SIGNAL(movementEnded()), SLOT(scrollEndDrag()));
     connect(view, SIGNAL(movingChanged()), SLOT(scroll()));
-
-    connect(view, SIGNAL(flickStarted()), SLOT(momentumScrollBegin()));
-    connect(view, SIGNAL(flickEnded()), SLOT(momentumScrollEnd()));
 }
 
 QString ScrollViewManager::qmlComponentFile(const QVariantMap& properties) const {

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -43,13 +43,14 @@ public:
     removeListViewItem(QQuickItem* item, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
     static QQuickItem* scrollViewContentItem(QQuickItem* item, int position);
 
+public Q_SLOTS:
+    void momentumScrollBegin(QQuickItem* item);
+    void momentumScrollEnd(QQuickItem* item);
+
 private Q_SLOTS:
     void scrollBeginDrag();
     void scrollEndDrag();
     void scroll();
-
-    void momentumScrollBegin();
-    void momentumScrollEnd();
 
 private:
     QVariantMap buildEventData(QQuickItem* item) const;

--- a/ReactQt/runtime/src/qml/ReactScrollListView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollListView.qml
@@ -13,13 +13,15 @@ ListView{
     property int p_footerWidth: 0
 
     clip: true
-    contentHeight: contentItem.childrenRect.height
-    contentWidth: contentItem.childrenRect.width
     highlightFollowsCurrentItem: false
 
     onCountChanged: {
         if(scrollViewManager)
-            scrollViewManager.sendOnLayoutToJs(scrollViewRoot, contentX, contentY, contentWidth, contentHeight);
+            scrollViewManager.sendOnLayoutToJs(scrollViewRoot,
+                                               contentX,
+                                               contentY,
+                                               contentItem.childrenRect.width,
+                                               contentItem.childrenRect.height);
     }
 
     header: Item {
@@ -40,6 +42,16 @@ ListView{
 
         Component.onDestruction: {
             modelData.parent = null
+        }
+    }
+
+    onFlickingChanged: {
+        if(scrollViewManager) {
+            if(flicking) {
+                scrollViewManager.momentumScrollBegin(scrollViewRoot);
+            } else {
+                scrollViewManager.momentumScrollEnd(scrollViewRoot);
+            }
         }
     }
 }

--- a/ReactQt/runtime/src/qml/ReactScrollView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollView.qml
@@ -5,6 +5,7 @@ import React 0.1 as React
 Flickable {
     id: scrollViewRoot
 
+    property var scrollViewManager: null
     property bool p_onScroll: false
     property var flexbox: React.Flexbox {control: scrollViewRoot}
     property bool p_enableArrayScrollingOptimization: false
@@ -14,4 +15,14 @@ Flickable {
     clip: true
     contentHeight: contentItem.childrenRect.height
     contentWidth: contentItem.childrenRect.width
+
+    onFlickingChanged: {
+        if(scrollViewManager) {
+            if(flicking) {
+                scrollViewManager.momentumScrollBegin(scrollViewRoot);
+            } else {
+                scrollViewManager.momentumScrollEnd(scrollViewRoot);
+            }
+        }
+    }
 }

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -91,9 +91,6 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
     e.insert("locationY", local.y());
     e.insert("timestamp", QVariant::fromValue(event->timestamp()));
 
-    qDebug() << "!!! created event target: " << ap->tag();
-    qDebug() << "!!! objectName: " << target->objectName();
-
     return e;
 }
 // TODO:

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -32,6 +32,23 @@ const QString TOUCH_MOVE = "touchMove";
 
 const int RESET_CONTENT_HTTP_STATUS_CODE = 205;
 
+QQuickItem* getChildFromScrollView(QQuickItem* scrollView, const QPointF& scrollViewPos) {
+    QQuickItem* itemAt = nullptr;
+    QQuickItem* contentItem = scrollView->property("contentItem").value<QQuickItem*>();
+    if (!contentItem)
+        return nullptr;
+
+    QPointF contentItemPos = scrollView->mapToItem(contentItem, scrollViewPos);
+    QMetaObject::invokeMethod(scrollView,
+                              "itemAt",
+                              Qt::DirectConnection,
+                              Q_RETURN_ARG(QQuickItem*, itemAt),
+                              Q_ARG(qreal, contentItemPos.x()),
+                              Q_ARG(qreal, contentItemPos.y()));
+
+    return itemAt;
+}
+
 QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
     const QPointF& lp = event->localPos();
 
@@ -43,15 +60,23 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
     QPointF local = lp;
     forever {
         target = next;
-        next = target->childAt(local.x(), local.y());
-        if (next == nullptr || !next->isEnabled())
+        QString className(target->metaObject()->className());
+
+        if (className.startsWith("ReactScrollListView")) {
+            next = getChildFromScrollView(target, local);
+        } else {
+            next = target->childAt(local.x(), local.y());
+        }
+
+        if (next == nullptr || !next->isEnabled()) {
             break;
+        }
         local = target->mapToItem(next, local);
     }
 
     AttachedProperties* ap = AttachedProperties::get(target, false);
     if (ap == nullptr) {
-        // qWarning() << __PRETTY_FUNCTION__ << "target was not a reactItem";
+        qWarning() << __PRETTY_FUNCTION__ << "target was not a reactItem";
         return e;
     }
 
@@ -65,6 +90,9 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
     e.insert("locationX", local.x());
     e.insert("locationY", local.y());
     e.insert("timestamp", QVariant::fromValue(event->timestamp()));
+
+    qDebug() << "!!! created event target: " << ap->tag();
+    qDebug() << "!!! objectName: " << target->objectName();
 
     return e;
 }


### PR DESCRIPTION
This PR is a result of investigation of issue https://github.com/status-im/status-react/issues/5597
It solves 2 problems.

1) `ListView::childAt()` doesn't always correctly finds contentItem (positioning of contentItem is a mistery sometimes...). So `RootView::makeReactTouchEvent` changed a bit to use `ListView::itemAt` instead.

2) It turned out that when the user scrolls scrollview to the end with the mouse wheel and makes one more wheel movement already at the end of scrollview (quite often case), Qt doesnt send `flickEnded` signal. 
That results in incorrect amount of `momentumScrollBegin` and `momentumScrollEnd` events sent to js ScrollView.
That results in ScrollView "thinking" that it is still moves.
That results in all mouse events intercepted by ScrollView and not propagated to childs.
So that was reason why in status-react we sometimes have not working touchables within scrollview.
