### PR TITLE
Fix svg blurriness

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
@@ -77,6 +77,8 @@ void ImageManager::manageSource(const QVariantMap& imageSource, QQuickItem* imag
         return;
     }
 
+    image->setProperty("isSVG", source.toString(QUrl::RemoveQuery).endsWith("svg"));
+
     if (source.scheme() == "file" && imageSource[URI_KEY].toString().startsWith(FILE_SCHEME)) {
         source = QUrl(imageSource[URI_KEY].toString().replace(FILE_SCHEME, ""));
     }

--- a/ReactQt/runtime/src/qml/ReactImage.qml
+++ b/ReactQt/runtime/src/qml/ReactImage.qml
@@ -17,6 +17,7 @@ React.Item {
     property bool p_onLayout: false
     property double p_blurRadius: 0
     property string p_resizeMode: 'cover'
+    property bool isSVG: false
 
     property var imageManager: null
     property string managedSource
@@ -41,6 +42,11 @@ React.Item {
         fillMode: fillModeFromResizeMode(imageRoot.p_resizeMode)
         source: imageRoot.managedSource
         visible: false //image not visible, because it is followed by effects and last effect is visible
+
+        //svg images sometimes contain internal height and width specification and gets
+        //blurry when resized. To avoid this we set sourceSize that supercedes internal svg settings
+        sourceSize.width: isSVG ? flexbox.p_width : undefined
+        sourceSize.height: isSVG ? flexbox.p_height : undefined
     }
 
     FastBlur {


### PR DESCRIPTION
Fixes #322 

Svg images sometimes contain internal height and width specification and get blurry when resized. To avoid this we can set sourceSize that supercedes internal svg settings.