### PR TITLE
Fix shell formatting

### DIFF
--- a/docs/CreateNewApp.md
+++ b/docs/CreateNewApp.md
@@ -2,21 +2,21 @@
 
 In order to setup the RN-desktop project, execute these terminal commands:
 
+```sh
+npm install -g react-native-cli # Or use Yarn
+react-native init DesktopSampleApp --version status-im/react-native-desktop
+cd DesktopSampleApp
+react-native desktop
 ```
-~$ npm install -g react-native-cli // Or use Yarn
-~$ react-native init DesktopSampleApp --version status-im/react-native-desktop
-~$ cd DesktopSampleApp
-~/DesktopSampleApp$ react-native desktop
 
-```
 If you're using macOS, run these commands in separate shells:
-```
-~/DesktopSampleApp$ npm start
-~/DesktopSampleApp$ node node_modules/react-native/ubuntu-server.js
+```sh
+npm start
+node node_modules/react-native/ubuntu-server.js
 ```
 
 Afterwards, execute:
-```
-~/DesktopSampleApp$ react-native run-desktop
+```sh
+react-native run-desktop
 ```
 (On non-macOS systems, `npm start` and `node ubuntu-server.js` will be executed automatically by the above command)


### PR DESCRIPTION
* Removed "\~$" and "~/DesktopSampleApp$" - This is mostly confusing imo. I think I get that you're emphasising this is the shell, but my shell doesn't look like this and I don't use my home dir directly for source code.
* Switched javascript comment `//` to shell comment `#`
* Set the code block language to shell (sh).

This way people can copy and run the code (after reading it hopefully).

This is a "drive by"-contribution, meaning I haven't invested time into consistency for example (I only read this file). I won't be offended if it's rejected.