### PR TITLE
Support inverted property for FlatList component

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -179,12 +179,19 @@ void ScrollViewManager::momentumScrollEnd(QQuickItem* item) {
 void ScrollViewManager::addTransformation(QQuickItem* item, QVariantList transform) {
 
     QVector<float> transformVector;
-    foreach (QVariant v, transform)
-        transformVector << v.value<float>();
+    foreach (QVariant v, transform) {
+        if (v.canConvert(QMetaType::Double)) {
+            transformVector << v.value<float>();
+        } else {
+            return;
+        }
+    }
 
     QQmlListReference r(item, "transform");
-    r.clear();
-    r.append(new MatrixTransform(transformVector, item));
+    if (r.canAppend()) {
+        r.clear();
+        r.append(new MatrixTransform(transformVector, item));
+    }
 }
 
 bool ScrollViewManager::eventFilter(QObject* scrollView, QEvent* event) {

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -13,9 +13,11 @@
 
 #include <QQmlComponent>
 #include <QQuickItem>
+#include <QSet>
 #include <QString>
 #include <QVariant>
 #include <QVariantList>
+#include <QWheelEvent>
 
 #include <QDebug>
 
@@ -174,6 +176,48 @@ void ScrollViewManager::momentumScrollEnd(QQuickItem* item) {
     notifyJsAboutEvent(tag(item), "momentumScrollEnd", buildEventData(item));
 }
 
+void ScrollViewManager::addTransformation(QQuickItem* item, QVariantList transform) {
+
+    QVector<float> transformVector;
+    foreach (QVariant v, transform)
+        transformVector << v.value<float>();
+
+    QQmlListReference r(item, "transform");
+    r.clear();
+    r.append(new MatrixTransform(transformVector, item));
+}
+
+bool ScrollViewManager::eventFilter(QObject* scrollView, QEvent* event) {
+
+    static QSet<QWheelEvent*> artificialEvents;
+
+    if (event->type() == QEvent::Wheel) {
+
+        QWheelEvent* e = static_cast<QWheelEvent*>(event);
+        bool shouldInvertWheelEvents = scrollView->property("invertedScroll").toBool();
+
+        if (shouldInvertWheelEvents && !artificialEvents.contains(e)) {
+            QWheelEvent* modifiedEvent = new QWheelEvent(e->posF(),
+                                                         e->globalPosF(),
+                                                         -e->pixelDelta(),
+                                                         e->angleDelta(),
+                                                         e->delta(),
+                                                         e->orientation(),
+                                                         e->buttons(),
+                                                         e->modifiers(),
+                                                         e->phase(),
+                                                         e->source(),
+                                                         true);
+            artificialEvents.insert(modifiedEvent);
+            QCoreApplication::sendEvent(scrollView, modifiedEvent);
+            artificialEvents.remove(modifiedEvent);
+            delete modifiedEvent;
+            return true;
+        }
+    }
+    return false;
+}
+
 namespace {
 template <typename TP> TP propertyValue(QQuickItem* item, const QString& property) {
     return QQmlProperty(item, property).read().value<TP>();
@@ -207,6 +251,7 @@ void ScrollViewManager::configureView(QQuickItem* view) const {
     ViewManager::configureView(view);
     view->setProperty("scrollViewManager", QVariant::fromValue((QObject*)this));
     // This would be prettier with a Functor version, but connect doesnt support it
+    view->installEventFilter((QObject*)this);
     connect(view, SIGNAL(movementStarted()), SLOT(scrollBeginDrag()));
     connect(view, SIGNAL(movementEnded()), SLOT(scrollEndDrag()));
     connect(view, SIGNAL(movingChanged()), SLOT(scroll()));

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -46,6 +46,10 @@ public:
 public Q_SLOTS:
     void momentumScrollBegin(QQuickItem* item);
     void momentumScrollEnd(QQuickItem* item);
+    void addTransformation(QQuickItem* item, QVariantList transform);
+
+protected:
+    bool eventFilter(QObject* scrollView, QEvent* e) override;
 
 private Q_SLOTS:
     void scrollBeginDrag();

--- a/ReactQt/runtime/src/layout/flexbox.cpp
+++ b/ReactQt/runtime/src/layout/flexbox.cpp
@@ -230,6 +230,7 @@ QString Flexbox::flexDirection() {
 
 void Flexbox::setFlexDirection(const QString& value) {
     if (value != d_ptr->m_flexDirection) {
+        d_ptr->m_flexDirection = value;
         YGNodeStyleSetFlexDirection(d_ptr->m_node, flexDirectionByString[value]);
         flexDirectionChanged();
     }
@@ -241,6 +242,7 @@ QString Flexbox::justifyContent() {
 
 void Flexbox::setJustifyContent(const QString& value) {
     if (value != d_ptr->m_justifyContent) {
+        d_ptr->m_justifyContent = value;
         YGNodeStyleSetJustifyContent(d_ptr->m_node, justificationByString[value]);
         justifyContentChanged();
     }
@@ -384,6 +386,7 @@ QString Flexbox::alignItems() {
 
 void Flexbox::setAlignItems(const QString& value) {
     if (value != d_ptr->m_alignItems) {
+        d_ptr->m_alignItems = value;
         YGNodeStyleSetAlignItems(d_ptr->m_node, alignByString[value]);
         alignItemsChanged();
     }
@@ -395,6 +398,7 @@ QString Flexbox::alignContent() {
 
 void Flexbox::setAlignContent(const QString& value) {
     if (value != d_ptr->m_alignContent) {
+        d_ptr->m_alignContent = value;
         YGNodeStyleSetAlignContent(d_ptr->m_node, alignByString[value]);
         alignContentChanged();
     }
@@ -406,6 +410,7 @@ QString Flexbox::alignSelf() {
 
 void Flexbox::setAlignSelf(const QString& value) {
     if (value != d_ptr->m_alignSelf) {
+        d_ptr->m_alignSelf = value;
         YGNodeStyleSetAlignSelf(d_ptr->m_node, alignByString[value]);
         alignSelfChanged();
     }
@@ -551,6 +556,7 @@ QString Flexbox::flexWrap() {
 
 void Flexbox::setFlexWrap(const QString& value) {
     if (value != d_ptr->m_flexWrap) {
+        d_ptr->m_flexWrap = value;
         YGNodeStyleSetFlexWrap(d_ptr->m_node, wrapByString[value]);
         flexWrapChanged();
     }
@@ -639,6 +645,7 @@ QString Flexbox::display() {
 
 void Flexbox::setDisplay(const QString& value) {
     if (value != d_ptr->m_display) {
+        d_ptr->m_display = value;
         YGNodeStyleSetDisplay(d_ptr->m_node, displayByString[value]);
         displayChanged();
     }
@@ -650,6 +657,7 @@ QString Flexbox::overflow() {
 
 void Flexbox::setOverflow(const QString& value) {
     if (value != d_ptr->m_overflow) {
+        d_ptr->m_overflow = value;
         YGNodeStyleSetOverflow(d_ptr->m_node, overflowByString[value]);
         overflowChanged();
     }
@@ -661,6 +669,7 @@ QString Flexbox::position() {
 
 void Flexbox::setPosition(const QString& value) {
     if (value != d_ptr->m_position) {
+        d_ptr->m_position = value;
         YGNodeStyleSetPositionType(d_ptr->m_node, positionByString[value]);
         positionChanged();
     }
@@ -672,6 +681,7 @@ QString Flexbox::direction() {
 
 void Flexbox::setDirection(const QString& value) {
     if (value != d_ptr->m_direction) {
+        d_ptr->m_direction = value;
         YGNodeStyleSetDirection(d_ptr->m_node, directionByString[value]);
         directionChanged();
     }

--- a/ReactQt/runtime/src/qml/ReactScrollView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollView.qml
@@ -11,6 +11,16 @@ Flickable {
     property bool p_enableArrayScrollingOptimization: false
     property int p_headerHeight: 0
     property int p_footerWidth: 0
+    property var p_transform
+    property bool invertedScroll: false
+
+    onP_transformChanged: {
+        scrollViewManager.addTransformation(scrollViewRoot, p_transform)
+        //if scrollview vertically inveted we should remember that to adjust wheel events
+        var scaleY = p_transform[5];
+        invertedScroll = (scaleY < 0);
+    }
+
 
     clip: true
     contentHeight: contentItem.childrenRect.height

--- a/ReactQt/runtime/src/qml/ReactScrollView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollView.qml
@@ -17,8 +17,10 @@ Flickable {
     onP_transformChanged: {
         scrollViewManager.addTransformation(scrollViewRoot, p_transform)
         //if scrollview vertically inveted we should remember that to adjust wheel events
-        var scaleY = p_transform[5];
-        invertedScroll = (scaleY < 0);
+        if(p_transform.length > 5) {
+            var scaleY = p_transform[5];
+            invertedScroll = (scaleY < 0);
+        }
     }
 
 

--- a/ReactQt/runtime/src/reactitem.cpp
+++ b/ReactQt/runtime/src/reactitem.cpp
@@ -15,7 +15,7 @@
 
 #include "layout/flexbox.h"
 #include "reactitem.h"
-#include <QMatrix4x4>
+#include "utilities.h"
 
 namespace {
 Qt::PenStyle borderStyleToPenStyle(const QString& borderStyle) {
@@ -39,24 +39,6 @@ QString penStyleToBorderStyle(Qt::PenStyle penStyle) {
     }
 }
 } // namespace
-
-class MatrixTransform : public QQuickTransform {
-public:
-    MatrixTransform(const QVector<float>& transformMatrix, QQuickItem* parent)
-        : QQuickTransform(parent), m_item(qobject_cast<QQuickItem*>(parent)) {
-        memcpy(m_transformMatrix.data(), transformMatrix.constData(), 16 * sizeof(float));
-        m_transformMatrix.optimize();
-    }
-    void applyTo(QMatrix4x4* matrix) const override {
-        if (m_transformMatrix.isIdentity())
-            return;
-        matrix->translate(m_item->width() / 2, m_item->height() / 2);
-        *matrix *= m_transformMatrix;
-        matrix->translate(-m_item->width() / 2, -m_item->height() / 2);
-    }
-    QMatrix4x4 m_transformMatrix;
-    QQuickItem* m_item;
-};
 
 class ReactItemPrivate {
     Q_DECLARE_PUBLIC(ReactItem)
@@ -422,7 +404,7 @@ void ReactItem::setTransform(QVector<float>& transform) {
     d->transform = transform;
     QQmlListReference r(this, "transform");
     r.clear();
-    r.append(new MatrixTransform(transform, this));
+    r.append(new utilities::MatrixTransform(transform, this));
 }
 
 ReactItem::ReactItem(QQuickItem* parent) : QQuickPaintedItem(parent), d_ptr(new ReactItemPrivate(this)) {}

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -27,6 +27,19 @@ const int MINOR_VERSION = 1;
 
 namespace utilities {
 
+MatrixTransform::MatrixTransform(const QVector<float>& transformMatrix, QQuickItem* parent)
+    : QQuickTransform(parent), m_item(qobject_cast<QQuickItem*>(parent)) {
+    memcpy(m_transformMatrix.data(), transformMatrix.constData(), 16 * sizeof(float));
+    m_transformMatrix.optimize();
+}
+void MatrixTransform::applyTo(QMatrix4x4* matrix) const {
+    if (m_transformMatrix.isIdentity())
+        return;
+    matrix->translate(m_item->width() / 2, m_item->height() / 2);
+    *matrix *= m_transformMatrix;
+    matrix->translate(-m_item->width() / 2, -m_item->height() / 2);
+}
+
 void registerReactTypes() {
     qmlRegisterUncreatableType<AttachedProperties>(
         "React", MAJOR_VERSION, MINOR_VERSION, "React", "React is not meant to be created directly");

--- a/ReactQt/runtime/src/utilities.h
+++ b/ReactQt/runtime/src/utilities.h
@@ -12,6 +12,8 @@
 #ifndef UTILITIES
 #define UTILITIES
 
+#include <QMatrix4x4>
+#include <QQuickTransform>
 #include <QString>
 #include <QUrl>
 
@@ -19,6 +21,14 @@ class QQuickItem;
 class QQmlEngine;
 
 namespace utilities {
+
+class MatrixTransform : public QQuickTransform {
+public:
+    MatrixTransform(const QVector<float>& transformMatrix, QQuickItem* parent);
+    void applyTo(QMatrix4x4* matrix) const override;
+    QMatrix4x4 m_transformMatrix;
+    QQuickItem* m_item;
+};
 
 void registerReactTypes();
 QString normalizeInputEventName(const QString& eventName);

--- a/docs/ComponentsSupport.md
+++ b/docs/ComponentsSupport.md
@@ -4,7 +4,7 @@
 | ActivityIndicator           | +/-                  |
 | Button                      | +/-                  |
 | DatePickerIOS               |                      |
-| DrawerLayoutAndroid         |                      |
+| DrawerLayoutAndroid         | +/-                  |
 | FlatList                    |                      |
 | Image                       | +/-                  |
 | KeyboardAvoidingView        |                      |


### PR DESCRIPTION
`FlatList` component declared by react-native as an optimized scroll view that partially unloads items when they are out of visible area. In is based on `ScrollView`, so `react-native-desktop` works fine with it. 
The idea was to use FlatList in `status-react` desktop the same way mobile team does. To make scrolling without jumps in FlatList, mobile team uses `inverted` property. 

This PR goal is to fix `inverted` property to work correctly in desktop `FlatList`. Initially it didn't work because for inverting `Flatlist` code uses transformation that wasn't implemented in desktop `ScrollView`. Fixing it also revealed issue: when vertical transformation applied, Qt wheel events works  incorrectly and change scroll direction to opposite, so this was additionally fixed.

