### PR TITLE
remove a pointless configure_file call

### DIFF
--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -258,5 +258,3 @@ add_custom_target(
   copy-qmldir ALL
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${CMAKE_CURRENT_BINARY_DIR}/React
 )
-
-configure_file(../../../ubuntu-server.js ../../../ubuntu-server.js COPYONLY)


### PR DESCRIPTION
Based on dicussion from:
https://status-im.slack.com/archives/CB02G923X/p1536849803000200

I'm removing this line because it causes failures when building inside of a docker container, since `jenkins` user doesn't have write access to the parent directory of the repo.

Error:
```
CMake Error at /home/jenkins/workspace/status-react/combined/desktop-linux/node_modules/react-native/ReactQt/runtime/src/CMakeLists.txt:262 (configure_file):
  configure_file Problem configuring file
```
https://ci.status.im/job/status-react/job/combined/job/desktop-linux/963/console

Related to https://github.com/status-im/status-react/pull/5765