### PR TITLE
Remove default padding that is set on TextInput qml components

### DIFF
--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -24,6 +24,7 @@ Flickable {
         font.pointSize: textInputRoot.p_fontSize
         font.family: textInputRoot.p_fontFamily
         font.weight: textInputRoot.p_fontWeightEnum
+        padding: 0
 
         selectByKeyboard: true
         selectByMouse: true

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -20,6 +20,7 @@ TextField {
     font.pointSize: textInputRoot.p_fontSize
     font.family: textInputRoot.p_fontFamily
     font.weight: textInputRoot.p_fontWeightEnum
+    padding: 0
 
     selectByMouse: true
     background: Rectangle {


### PR DESCRIPTION
Default padding led to one-line text not fully visible when height is not specified for TextInput.