### PR TITLE
Detect right button mouse event

### DIFF
--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -79,6 +79,11 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
         qWarning() << __PRETTY_FUNCTION__ << "target was not a reactItem";
         return e;
     }
+    QString button;
+    if (event->button() & Qt::LeftButton)
+        button = "left";
+    else if (event->button() & Qt::RightButton)
+        button = "right";
 
     e.insert("target", ap->tag());
     e.insert("identifier", 1);
@@ -90,6 +95,7 @@ QVariantMap makeReactTouchEvent(QQuickItem* item, QMouseEvent* event) {
     e.insert("locationX", local.x());
     e.insert("locationY", local.y());
     e.insert("timestamp", QVariant::fromValue(event->timestamp()));
+    e.insert("button", button);
 
     return e;
 }
@@ -162,7 +168,7 @@ private Q_SLOTS:
 RootView::RootView(QQuickItem* parent) : ReactItem(parent), d_ptr(new RootViewPrivate(this)) {
     Q_D(RootView);
 
-    setAcceptedMouseButtons(Qt::LeftButton);
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
     setFiltersChildMouseEvents(true);
 
     d->bridge = new Bridge(this);


### PR DESCRIPTION
### Description
Fixes: #350
Additional field `button` added to press events that specifies "left" or "right" mouse button.

### Usage:
```
<TouchableOpacity
            onPress={(e) => {console.log(e.nativeEvent.button) }}
            >
            <Text>
              Press Me
            </Text>
          </TouchableOpacity>
```

### Notes:
Now `onPress`, `onRelease`, etc... generated by right mouse button the same way as for left mouse button. So all touchables within status-react will be clickable by right mouse button.
