### PR TITLE
Escape html in text

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -83,6 +83,10 @@ void TextManager::updateMeasureFunction(QQuickItem* textItem) {
     }
 }
 
+QString TextManager::escape(const QString& text) {
+    return text.toHtmlEscaped();
+}
+
 void TextManager::resizeToWidth(QQuickItem* textItem, double width) {
     textItem->setWidth(width);
     double contentWidth = textItem->property("contentWidth").value<double>();

--- a/ReactQt/runtime/src/componentmanagers/textmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.h
@@ -41,6 +41,7 @@ public:
 public slots:
     QVariant nestedPropertyValue(QQuickItem* item, const QString& propertyName);
     void updateMeasureFunction(QQuickItem* textItem);
+    QString escape(const QString& text);
 
 private:
     QQuickItem* parentTextItem(QQuickItem* textItem);

--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -143,7 +143,7 @@ TextEdit {
                 + (fontWeight ? ("font-weight:"+fontWeight+";") : "")
                 + (textDecorLine ? ("text-decoration:"+textDecorLine+";") : "")
                 + "\">"
-                + textString + "</span>";
+                + textManager.escape(textString) + "</span>";
 
         return result.replace(/\n/g, '<br>');
     }


### PR DESCRIPTION
Fixes #349
Text styling internally implemented wia html, so html-related characters in text should be escaped.

Test example:
```
  <TouchableOpacity
            onPress={(e) => {this.setState({text: "#include <QtCore>"})}}
            <Text style={styles.button}>
              {this.state.text}
            </Text>
          </TouchableOpacity>
```