### PR TITLE
Selective logging added

### DIFF
--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -151,6 +151,7 @@ set(
   componentmanagers/scrollviewmodel.cpp
   layout/flexbox.cpp
   utilities.cpp
+  logger.cpp
   communication/serverconnection.cpp
   communication/executor.cpp
   communication/websocketexecutor.cpp

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -40,6 +40,7 @@
 #include "eventdispatcher.h"
 #include "exceptionsmanager.h"
 #include "linkingmanager.h"
+#include "logger.h"
 #include "moduledata.h"
 #include "moduleinterface.h"
 #include "moduleloader.h"
@@ -235,6 +236,7 @@ void Bridge::reload() {
     setJsAppStarted(false);
 
     setupExecutor();
+    Logger::getInstance().sync();
 
     d->uiManager->reset();
     for (auto& md : d->modules) {

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -20,6 +20,7 @@
 #include "attachedproperties.h"
 #include "bridge.h"
 #include "layout/flexbox.h"
+#include "logger.h"
 #include "propertyhandler.h"
 #include "reactitem.h"
 #include "textmanager.h"
@@ -130,8 +131,7 @@ QQuickItem* ViewManager::createView(const QVariantMap& properties) {
     if (item == nullptr) {
         qCritical() << QString("Can't create QML item for component %1").arg(qmlSrc);
     } else {
-        qDebug() << "View is created. Address: " << item << ". Source QML file: " << qmlSrc
-                 << ". Props: " << properties;
+        rnLog(VIEWMANAGER) << "Created view: " << item << ". Source QML file: " << qmlSrc << ". Props: " << properties;
     }
     return item;
 }

--- a/ReactQt/runtime/src/layout/flexbox.cpp
+++ b/ReactQt/runtime/src/layout/flexbox.cpp
@@ -13,6 +13,7 @@
 #include "attachedproperties.h"
 #include "componentmanagers/viewmanager.h"
 
+#include "logger.h"
 #include <QDebug>
 #include <QMap>
 #include <QQuickItem>
@@ -124,8 +125,8 @@ void Flexbox::setMeasureFunction(ygnode_measure_function measureFunction) {
 void Flexbox::addChild(int index, Flexbox* child) {
     Q_ASSERT(child);
 
-    qDebug() << "Flexbox::addChild new YGNode: " << child->d_ptr->m_node << " for flexbox: " << child
-             << " will be inserted at: " << index << " into parent: " << this;
+    rnLog(FLEXBOX) << "::addChild new YGNode: " << child->d_ptr->m_node << " for flexbox: " << child
+                   << " will be inserted at: " << index << " into parent: " << this;
     YGNodeInsertChild(d_ptr->m_node, child->d_ptr->m_node, index);
 }
 
@@ -134,8 +135,8 @@ void Flexbox::removeChilds(const QList<int>& indicesToRemove) {
 
     QList<YGNodeRef> toRemove;
     for (int index : indicesToRemove) {
-        qDebug() << "Flexbox::removeChilds YGNode: " << YGNodeGetChild(d->m_node, index)
-                 << " will be removed at index: " << index << " from: " << this;
+        rnLog(FLEXBOX) << "::removeChilds YGNode: " << YGNodeGetChild(d->m_node, index)
+                       << " will be removed at index: " << index << " from: " << this;
         toRemove.push_back(YGNodeGetChild(d->m_node, index));
     }
 

--- a/ReactQt/runtime/src/logger.cpp
+++ b/ReactQt/runtime/src/logger.cpp
@@ -1,0 +1,74 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "logger.h"
+#include <QBuffer>
+
+const QString LOG_SETTINGS_FILE = "logger_settings.ini";
+
+Logger& Logger::getInstance() {
+    static Logger logger;
+    return logger;
+}
+
+Logger::~Logger() {
+    delete m_settings;
+    m_settings = nullptr;
+}
+
+QString& Logger::devNull() {
+    return m_devnull;
+}
+
+const QSettings& Logger::settings() {
+    return *m_settings;
+}
+
+void Logger::registerModule(const QString& moduleName) {
+    if (!m_settings->contains(moduleName)) {
+        m_settings->setValue(moduleName, true);
+    }
+}
+
+void Logger::sync() {
+    m_settings->sync();
+}
+
+Logger::Logger() {
+    m_settings = new QSettings(LOG_SETTINGS_FILE, QSettings::IniFormat);
+
+    registerModule(UIMANAGER);
+    registerModule(FLEXBOX);
+    registerModule(VIEWMANAGER);
+}
+
+QDebug rnLog(const QString& module) {
+    Logger& logger = Logger::getInstance();
+    logger.devNull().clear();
+
+    if (!logger.settings().contains(module)) {
+        qDebug() << "Logging not shown for unknown module: " << module;
+        return QDebug(&Logger::getInstance().devNull());
+    }
+
+    // if module not enabled, we redirect logging to string that will be cleared
+    // later. If enabled - text will appear in debug oputput
+    if (logger.settings().value(module).toBool()) {
+        QDebug debugStream = qDebug();
+        return (debugStream << module + ":");
+    } else {
+        return QDebug(&Logger::getInstance().devNull());
+    }
+}
+
+void registerLogModule(const QString& module) {
+    Logger::getInstance().registerModule(module);
+}

--- a/ReactQt/runtime/src/logger.cpp
+++ b/ReactQt/runtime/src/logger.cpp
@@ -48,6 +48,8 @@ Logger::Logger() {
     registerModule(UIMANAGER);
     registerModule(FLEXBOX);
     registerModule(VIEWMANAGER);
+    registerModule(NETWORKING);
+    registerModule(WEBSOCKET);
 }
 
 QDebug rnLog(const QString& module) {

--- a/ReactQt/runtime/src/logger.h
+++ b/ReactQt/runtime/src/logger.h
@@ -19,6 +19,8 @@
 const QString UIMANAGER = "UIManager";
 const QString FLEXBOX = "Flexbox";
 const QString VIEWMANAGER = "ViewManager";
+const QString NETWORKING = "Networking";
+const QString WEBSOCKET = "WebSocketModule";
 
 class Logger {
 

--- a/ReactQt/runtime/src/logger.h
+++ b/ReactQt/runtime/src/logger.h
@@ -1,0 +1,44 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef LOGGER
+#define LOGGER
+
+#include <QDebug>
+#include <QSettings>
+#include <QString>
+
+const QString UIMANAGER = "UIManager";
+const QString FLEXBOX = "Flexbox";
+const QString VIEWMANAGER = "ViewManager";
+
+class Logger {
+
+public:
+    static Logger& getInstance();
+    ~Logger();
+    QString& devNull();
+    const QSettings& settings();
+    void registerModule(const QString& moduleName);
+    void sync();
+
+private:
+    Logger();
+
+private:
+    QSettings* m_settings;
+    QString m_devnull;
+};
+
+QDebug rnLog(const QString& module);
+void registerLogModule(const QString& module);
+
+#endif // LOGGER

--- a/ReactQt/runtime/src/networking.cpp
+++ b/ReactQt/runtime/src/networking.cpp
@@ -21,6 +21,7 @@
 
 #include "bridge.h"
 #include "eventdispatcher.h"
+#include "logger.h"
 #include "networking.h"
 
 namespace {
@@ -42,10 +43,10 @@ public:
     void handleGetRequest(int requestId, const QNetworkRequest& request) {
         QNetworkReply* reply = nam->get(request);
         QObject::connect(reply, &QNetworkReply::metaDataChanged, [=]() {
-            qDebug() << "QNetworkReply::metaDataChange: didReceiveNetworkResponse responseCode: "
-                     << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                     << " replyUrl: " << reply->url().toString()
-                     << " headersList: " << headerListToMap(reply->rawHeaderPairs());
+            rnLog(NETWORKING) << "QNetworkReply::metaDataChange: didReceiveNetworkResponse responseCode: "
+                              << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
+                              << " replyUrl: " << reply->url().toString()
+                              << " headersList: " << headerListToMap(reply->rawHeaderPairs());
             bridge->eventDispatcher()->sendDeviceEvent(
                 "didReceiveNetworkResponse",
                 QVariantList{requestId,
@@ -61,8 +62,8 @@ public:
                                                        QVariantList{requestId, reply->read(bytesReceived)});
         });
         QObject::connect(reply, &QNetworkReply::finished, [=]() {
-            qDebug() << "NetworkingPrivate::handleGetRequest QNetworkReply::finished requestId: " << requestId
-                     << "error: " << reply->errorString();
+            rnLog(NETWORKING) << "NetworkingPrivate::handleGetRequest QNetworkReply::finished requestId: " << requestId
+                              << "error: " << reply->errorString();
             reply->deleteLater();
             bridge->eventDispatcher()->sendDeviceEvent("didReceiveNetworkData",
                                                        QVariantList{requestId, reply->readAll()});
@@ -87,8 +88,8 @@ void Networking::sendRequest(const QString& method,
                              double requestIdCallbackId) {
     Q_D(Networking);
 
-    qDebug() << "Networking::sendRequest url:" << url << " headers:" << headers << " data:" << data
-             << " method: " << method;
+    rnLog(NETWORKING) << "Networking::sendRequest url:" << url << " headers:" << headers << " data:" << data
+                      << " method: " << method;
 
     QNetworkRequest request(url);
 
@@ -107,7 +108,6 @@ void Networking::sendRequest(const QString& method,
 }
 
 void Networking::abortRequest(int requestId) {
-    // qDebug() << __PRETTY_FUNCTION__ << request;
     Q_D(Networking);
     QNetworkReply* reply = d->activeConnections[requestId];
     if (reply == nullptr) {

--- a/ReactQt/runtime/src/uimanager.cpp
+++ b/ReactQt/runtime/src/uimanager.cpp
@@ -29,6 +29,7 @@
 #include "componentmanagers/scrollviewmanager.h"
 #include "componentmanagers/viewmanager.h"
 #include "layout/flexbox.h"
+#include "logger.h"
 #include "moduledata.h"
 #include "modulemethod.h"
 #include "reactitem.h"
@@ -38,8 +39,6 @@
 int UIManager::m_nextRootTag = 1;
 
 void UIManager::removeSubviewsFromContainerWithID(int containerReactTag) {
-    // qDebug() << __PRETTY_FUNCTION__;
-
     QQuickItem* item = m_views.value(containerReactTag);
     if (item == nullptr) {
         qWarning() << __PRETTY_FUNCTION__ << "Attempting to access unknown view";
@@ -54,8 +53,6 @@ void UIManager::removeSubviewsFromContainerWithID(int containerReactTag) {
 }
 
 void UIManager::measure(int reactTag, const ModuleInterface::ListArgumentBlock& callback) {
-    // qDebug() << __PRETTY_FUNCTION__;
-
     QQuickItem* item = m_views.value(reactTag);
     if (item == nullptr) {
         qWarning() << "Attempting to access unknown view";
@@ -70,8 +67,6 @@ void UIManager::measure(int reactTag, const ModuleInterface::ListArgumentBlock& 
 }
 
 void UIManager::updateView(int reactTag, const QString& viewName, const QVariantMap& properties) {
-    // qDebug() << __PRETTY_FUNCTION__ << reactTag << viewName << properties;
-
     QQuickItem* item = m_views.value(reactTag);
     if (item == nullptr) {
         qWarning() << "Attempting to update properties on unknown view; reactTag=" << reactTag
@@ -134,13 +129,13 @@ void UIManager::manageChildren(int containerReactTag,
         return;
     }
 
-    qDebug() << "UIManager::manageChildren for containerReactTag: " << containerReactTag
-             << " moveFromIndicies: " << moveFromIndicies << " moveToIndices: " << moveToIndices
-             << " addChildReactTags: " << addChildReactTags << " addAtIndices: " << addAtIndices
-             << " removeAtIndices: " << removeAtIndices;
+    rnLog(UIMANAGER) << "::manageChildren for containerReactTag: " << containerReactTag
+                     << " moveFromIndicies: " << moveFromIndicies << " moveToIndices: " << moveToIndices
+                     << " addChildReactTags: " << addChildReactTags << " addAtIndices: " << addAtIndices
+                     << " removeAtIndices: " << removeAtIndices;
 
-    qDebug() << "UIManager::manageChildren container->childItems().size(): " << container->childItems().size();
-    qDebug() << "UIManager::manageChildren container->childItems(): " << container->childItems();
+    rnLog(UIMANAGER) << "::manageChildren container->childItems().size(): " << container->childItems().size();
+    rnLog(UIMANAGER) << "::manageChildren container->childItems(): " << container->childItems();
 
     Q_ASSERT(moveFromIndicies.size() == moveToIndices.size());
     Q_ASSERT(addChildReactTags.size() == addAtIndices.size());
@@ -210,9 +205,9 @@ void UIManager::manageChildren(int containerReactTag,
             auto containerFlexbox = Flexbox::findFlexbox(container);
             auto childFlexbox = Flexbox::findFlexbox(child);
             if (containerFlexbox && childFlexbox) {
-                qDebug() << "UIManager::manageChildren containerFlexbox->addChild Parent container: " << container
-                         << " parent container flexbox: " << containerFlexbox << " Child item: " << child
-                         << " child flexbox: " << childFlexbox << " position to add at: " << i;
+                rnLog(UIMANAGER) << "::manageChildren containerFlexbox->addChild Parent container: " << container
+                                 << " parent container flexbox: " << containerFlexbox << " Child item: " << child
+                                 << " child flexbox: " << childFlexbox << " position to add at: " << i;
                 containerFlexbox->addChild(i, childFlexbox);
             }
         }
@@ -289,25 +284,18 @@ void UIManager::measureLayoutRelativeToParent(int reactTag,
 void UIManager::setJSResponder(int reactTag, bool blockNativeResponder) {
     Q_UNUSED(reactTag);
     Q_UNUSED(blockNativeResponder);
-
-    // qDebug() << __PRETTY_FUNCTION__;
 }
 
-void UIManager::clearJSResponder() {
-    // qDebug() << __PRETTY_FUNCTION__;
-}
+void UIManager::clearJSResponder() {}
 
 // in iOS, resign first responder (actual)
 void UIManager::blur(int reactTag) {
     Q_UNUSED(reactTag);
-
-    // qDebug() << __PRETTY_FUNCTION__;
 }
 
 void UIManager::createView(int reactTag, const QString& viewName, int rootTag, const QVariantMap& props) {
     Q_UNUSED(rootTag);
 
-    // qDebug() << __PRETTY_FUNCTION__ << reactTag << viewName << rootTag << props;
     ComponentData* cd = m_componentData.value(viewName);
     if (cd == nullptr) {
         qCritical() << "Attempt to create unknown view of type" << viewName;
@@ -363,7 +351,6 @@ void UIManager::findSubviewIn(int reactTag, const QPointF& point, const ModuleIn
 }
 
 void UIManager::dispatchViewManagerCommand(int reactTag, int commandID, const QVariantList& commandArgs) {
-    // qDebug() << __PRETTY_FUNCTION__ << reactTag << commandID << commandArgs;
     QQuickItem* item = m_views.value(reactTag);
     if (item == nullptr) {
         qWarning() << __PRETTY_FUNCTION__ << "Attempting to access unknown view";
@@ -390,7 +377,6 @@ void UIManager::takeSnapshot(const QString& target,
                              const QVariantMap& options,
                              const ModuleInterface::ListArgumentBlock& resolve,
                              const ModuleInterface::ListArgumentBlock& reject) {
-    // qDebug() << __PRETTY_FUNCTION__ << target << options;
     QString imageFormat = options.value("format").toString();
     if (imageFormat.isEmpty()) {
         imageFormat = "png";
@@ -464,7 +450,6 @@ void UIManager::reset() {
 }
 
 void UIManager::setBridge(Bridge* bridge) {
-    // qDebug() << __PRETTY_FUNCTION__;
     if (m_bridge != nullptr) {
         qCritical() << "Bridge already set, UIManager already initialised?";
         return;
@@ -517,8 +502,6 @@ QVariantMap UIManager::constantsToExport() {
     QVariantMap rc;
 
     for (const ComponentData* componentData : m_componentData) {
-        // qDebug() << "Checking" << componentData->name();
-
         QVariantMap managerInfo;
 
         managerInfo.insert("Manager", componentData->manager()->moduleName().replace("RCT", ""));

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -18,6 +18,7 @@
 #include "componentmanagers/imagemanager.h"
 #include "componentmanagers/viewmanager.h"
 #include "layout/flexbox.h"
+#include "logger.h"
 #include "reactitem.h"
 #include "rootview.h"
 #include "utilities.h"
@@ -125,8 +126,8 @@ void insertChildItemAt(QQuickItem* item, int position, QQuickItem* parent) {
 void removeFlexboxChilds(QQuickItem* item, const QList<int>& removeAtIndices) {
     auto flexbox = Flexbox::findFlexbox(item);
     if (flexbox) {
-        qDebug() << "utilities::removeFlexboxChilds remove children at indexes" << removeAtIndices
-                 << " from parent item: " << item << " parent flexbox: " << flexbox;
+        rnLog(FLEXBOX) << "utilities::removeFlexboxChilds remove children at indexes" << removeAtIndices
+                       << " from parent item: " << item << " parent flexbox: " << flexbox;
         flexbox->removeChilds(removeAtIndices);
     }
 }

--- a/ReactQt/runtime/src/websocketmodule.cpp
+++ b/ReactQt/runtime/src/websocketmodule.cpp
@@ -15,6 +15,7 @@
 
 #include "bridge.h"
 #include "eventdispatcher.h"
+#include "logger.h"
 #include "websocketmodule.h"
 
 class WebSocketModulePrivate {
@@ -28,7 +29,7 @@ public:
 
         QObject::connect(socket, &QWebSocket::connected, [=]() {
 #ifdef RCT_DEV
-            qDebug() << "Socket connected. SocketId:" << socketId;
+            rnLog(WEBSOCKET) << "Socket connected. SocketId:" << socketId;
 #endif // RCT_DEV
             if (bridge) {
                 bridge->eventDispatcher()->sendDeviceEvent("websocketOpen", QVariantMap{{"id", socketId}});
@@ -39,7 +40,7 @@ public:
             sockets.remove(socketId);
             socket->deleteLater();
 #ifdef RCT_DEV
-            qDebug() << "Socket disconnected. SocketId:" << socketId;
+            rnLog(WEBSOCKET) << "Socket disconnected. SocketId:" << socketId;
 #endif // RCT_DEV
             if (bridge) {
                 bridge->eventDispatcher()->sendDeviceEvent("websocketClosed",
@@ -52,7 +53,7 @@ public:
 
         QObject::connect(socket, &QWebSocket::textMessageReceived, [=](const QString& message) {
 #ifdef RCT_DEV
-            qDebug() << QString("Text message %1 received for SocketId %2").arg(message).arg(socketId);
+            rnLog(WEBSOCKET) << QString("Text message %1 received for SocketId %2").arg(message).arg(socketId);
 #endif // RCT_DEV
             if (bridge) {
                 bridge->eventDispatcher()->sendDeviceEvent(
@@ -62,7 +63,8 @@ public:
 
         QObject::connect(socket, &QWebSocket::binaryMessageReceived, [=](const QByteArray& message) {
 #ifdef RCT_DEV
-            qDebug() << QString("Binary message of size %1 received for SocketId %2").arg(message.size()).arg(socketId);
+            rnLog(WEBSOCKET)
+                << QString("Binary message of size %1 received for SocketId %2").arg(message.size()).arg(socketId);
 #endif // RCT_DEV
             if (bridge) {
                 bridge->eventDispatcher()->sendDeviceEvent(
@@ -74,7 +76,7 @@ public:
                          static_cast<void (QWebSocket::*)(QAbstractSocket::SocketError)>(&QWebSocket::error),
                          [=](QAbstractSocket::SocketError) {
 #ifdef RCT_DEV
-                             qDebug() << "Socket error: " << socket->errorString();
+                             rnLog(WEBSOCKET) << "Socket error: " << socket->errorString();
 #endif // RCT_DEV
                          });
 
@@ -89,7 +91,7 @@ void WebSocketModule::connect(const QUrl& url,
     Q_D(WebSocketModule);
 
 #ifdef RCT_DEV
-    qDebug() << "WebSocketModule::connect with args: url: " << url << " socketId: " << socketId;
+    rnLog(WEBSOCKET) << "WebSocketModule::connect with args: url: " << url << " socketId: " << socketId;
 #endif // RCT_DEV
 
     d->createSocketConnection(url, socketId);
@@ -97,7 +99,7 @@ void WebSocketModule::connect(const QUrl& url,
 
 void WebSocketModule::send(const QString& message, qlonglong socketId) {
 #ifdef RCT_DEV
-    qDebug() << "WebSocketModule::send with args: message: " << message << " socketId: " << socketId;
+    rnLog(WEBSOCKET) << "WebSocketModule::send with args: message: " << message << " socketId: " << socketId;
 #endif // RCT_DEV
     Q_D(WebSocketModule);
     if (d->sockets.contains(socketId)) {
@@ -108,7 +110,8 @@ void WebSocketModule::send(const QString& message, qlonglong socketId) {
 
 void WebSocketModule::sendBinary(const QString& base64String, qlonglong socketId) {
 #ifdef RCT_DEV
-    qDebug() << "WebSocketModule::sendBinary with args: base64String: " << base64String << " socketId: " << socketId;
+    rnLog(WEBSOCKET) << "WebSocketModule::sendBinary with args: base64String: " << base64String
+                     << " socketId: " << socketId;
 #endif // RCT_DEV
     Q_D(WebSocketModule);
     if (d->sockets.contains(socketId)) {
@@ -119,7 +122,7 @@ void WebSocketModule::sendBinary(const QString& base64String, qlonglong socketId
 
 void WebSocketModule::ping(qlonglong socketId) {
 #ifdef RCT_DEV
-    qDebug() << "WebSocketModule::ping with args: socketId: " << socketId;
+    rnLog(WEBSOCKET) << "WebSocketModule::ping with args: socketId: " << socketId;
 #endif // RCT_DEV
     Q_D(WebSocketModule);
     if (d->sockets.contains(socketId)) {
@@ -130,7 +133,7 @@ void WebSocketModule::ping(qlonglong socketId) {
 
 void WebSocketModule::close(qlonglong socketId) {
 #ifdef RCT_DEV
-    qDebug() << "WebSocketModule::close Closing socket socketId: " << socketId;
+    rnLog(WEBSOCKET) << "WebSocketModule::close Closing socket socketId: " << socketId;
 #endif // RCT_DEV
     Q_D(WebSocketModule);
     if (d->sockets.contains(socketId)) {


### PR DESCRIPTION
Fixes #329

- Added logger that can be turned on/off for specific module. 
- Replaced qDebug() calls with new logger in Flexbox, ViewManager, UIManager, Networking, WebSocketModule.

Logger creates `logger_settings.ini` file in a `desktop` directory of `react-native-desktop` project. By changing settings in that file you can turn on and off logging for different modules. To pickup changes in `logger_settings.ini` reloading required (but not restarting).

This version of logger works "as is" with 3rd party modules. PR added to add RCTStatus support - https://github.com/status-im/status-react/pull/6086
