### PR TITLE
Fixed popup menu closing

### DIFF
--- a/ReactQt/runtime/src/reactitem.cpp
+++ b/ReactQt/runtime/src/reactitem.cpp
@@ -407,7 +407,9 @@ void ReactItem::setTransform(QVector<float>& transform) {
     r.append(new utilities::MatrixTransform(transform, this));
 }
 
-ReactItem::ReactItem(QQuickItem* parent) : QQuickPaintedItem(parent), d_ptr(new ReactItemPrivate(this)) {}
+ReactItem::ReactItem(QQuickItem* parent) : QQuickPaintedItem(parent), d_ptr(new ReactItemPrivate(this)) {
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
+}
 
 ReactItem::~ReactItem() {}
 


### PR DESCRIPTION
Fixes #321

Popup menu  creates an invisible view (when opened) that covers all app to detect clicks outside menu. 
But it appeared that in qml implementations of `View` we weren't accepting mouse events, so menu wasn't closing.

p.s.
R to check this agains `status-react` added - https://github.com/status-im/status-react/pull/6167