### PR TITLE
Fixed double sending of onTextChange events

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -172,10 +172,15 @@ type AndroidProps = $ReadOnly<{|
   inlineImagePadding?: ?number,
 |}>;
 
+type DesktopProps = $ReadOnly<{|
+  submitShortcut?: ?object,
+|}>;
+
 type Props = $ReadOnly<{|
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
+  ...DesktopProps,
   autoCapitalize?: ?AutoCapitalize,
   autoCorrect?: ?boolean,
   autoFocus?: ?boolean,
@@ -786,6 +791,7 @@ const TextInput = createReactClass({
       'username',
       'password',
     ]),
+    submitShortcut: PropTypes.object,
   },
   getDefaultProps(): Object {
     return {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -106,9 +106,7 @@ bool TextInputManager::onKeyPressed(QQuickItem* textInput,
                                     QVariantList modifiers,
                                     QString submitKeyText,
                                     QVariantList submitModifiers) {
-    bool submitKeysSet = !submitKeyText.isEmpty() && !submitModifiers.isEmpty();
-
-    if (submitKeysSet && keyText == submitKeyText && modifiers == submitModifiers) {
+    if (!submitKeyText.isEmpty() && (keyText == submitKeyText) && (modifiers == submitModifiers)) {
         sendOnSubmitEditingToJs(textInput);
         return true;
     } else {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -61,7 +61,8 @@ QStringList TextInputManager::customDirectEventTypes() {
 }
 
 void TextInputManager::sendTextEditedToJs(QQuickItem* textInput) {
-    sendTextInputEvent(textInput, EVENT_ON_TEXT_CHANGE);
+    QString text = textInput->property("text").toString();
+    sendTextInputEvent(textInput, EVENT_ON_TEXT_CHANGE, QVariantMap{{"text", text}});
 }
 
 void TextInputManager::sendSelectionChangeToJs(QQuickItem* textInput) {
@@ -122,13 +123,12 @@ void TextInputManager::sendTextInputEvent(QQuickItem* textInput, QString eventNa
     QString text = textInput->property("text").toString();
     int parentTag = tag(textInput->parentItem());
 
-    QVariantMap eventData = QVariantMap{{"target", parentTag}, {"text", text}};
+    QVariantMap eventData = QVariantMap{{"target", parentTag}};
     if (!additionalEventData.isEmpty()) {
         for (auto iterator = additionalEventData.constBegin(); iterator != additionalEventData.constEnd(); ++iterator) {
             eventData.insert(iterator.key(), iterator.value());
         }
     }
-
     notifyJsAboutEvent(parentTag, eventName, eventData);
 }
 

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -90,7 +90,7 @@ void TextInputManager::sendOnFocusToJs(QQuickItem* textInput) {
     sendTextInputEvent(textInput, EVENT_ON_FOCUS);
 }
 
-void TextInputManager::sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QStringList modifiers) {
+void TextInputManager::sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QVariantList modifiers) {
     sendTextInputEvent(textInput, EVENT_ON_KEY_PRESS, QVariantMap{{"key", keyText}, {"modifiers", modifiers}});
 }
 
@@ -98,6 +98,21 @@ void TextInputManager::sendOnContentSizeChange(QQuickItem* textInput, double wid
     sendTextInputEvent(textInput,
                        EVENT_ON_CONTENT_SIZE_CHANGE,
                        QVariantMap{{"contentSize", QVariantMap{{"width", width}, {"height", height}}}});
+}
+
+bool TextInputManager::onKeyPressed(QQuickItem* textInput,
+                                    QString keyText,
+                                    QVariantList modifiers,
+                                    QString submitKeyText,
+                                    QVariantList submitModifiers) {
+
+    if (keyText == submitKeyText && modifiers == submitModifiers) {
+        sendOnSubmitEditingToJs(textInput);
+        return true;
+    } else {
+        sendOnKeyPressToJs(textInput, keyText, modifiers);
+        return false;
+    }
 }
 
 void TextInputManager::sendTextInputEvent(QQuickItem* textInput, QString eventName, QVariantMap additionalEventData) {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -106,8 +106,9 @@ bool TextInputManager::onKeyPressed(QQuickItem* textInput,
                                     QVariantList modifiers,
                                     QString submitKeyText,
                                     QVariantList submitModifiers) {
+    bool submitKeysSet = !submitKeyText.isEmpty() && !submitModifiers.isEmpty();
 
-    if (keyText == submitKeyText && modifiers == submitModifiers) {
+    if (submitKeysSet && keyText == submitKeyText && modifiers == submitModifiers) {
         sendOnSubmitEditingToJs(textInput);
         return true;
     } else {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.h
@@ -36,8 +36,13 @@ public slots:
     void sendOnSubmitEditingToJs(QQuickItem* textInput);
     void sendOnEndEditingToJs(QQuickItem* textInput);
     void sendOnFocusToJs(QQuickItem* textInput);
-    void sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QStringList modifiers);
+    void sendOnKeyPressToJs(QQuickItem* textInput, QString keyText, QVariantList modifiers);
     void sendOnContentSizeChange(QQuickItem* textInput, double width, double height);
+    bool onKeyPressed(QQuickItem* textInput,
+                      QString keyText,
+                      QVariantList modifiers,
+                      QString submitKeyText,
+                      QVariantList submitModifiers);
 
 private:
     virtual QString qmlComponentFile(const QVariantMap& properties) const override;

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -30,7 +30,7 @@ Item {
     property var p_submitShortcut: defaultShortcut(p_multiline)
 
     property var flexbox: React.Flexbox {control: textInputRoot; viewManager: textInputManager}
-    property bool sendTextChanged: true
+    property bool jsTextChange: false
 
     function defaultShortcut(multiline) {
         if(multiline)
@@ -42,20 +42,27 @@ Item {
     objectName: p_nativeID
 
     onP_textChanged: {
-        if(textInputControl) {
-            sendTextChanged = false
+        if(textInputControl /*&& !textInputManager.isUserTextChange(textInputControl, p_text)*/) {
+            jsTextChange = true
 
             if(p_multiline) {
-                var cursorPos = textInputControl.cursorPosition
+                var oldCursorPos = textInputControl.cursorPosition
+                var cursorAtEnd = (textInputControl.textAreaLength === textInputControl.cursorPosition)
                 textInputControl.text = p_text
-                cursorPos = Math.min(cursorPos+1, textInputControl.length)
+
+                var cursorPos;
+                if(cursorAtEnd)
+                    cursorPos = textInputControl.textAreaLength
+                else
+                    cursorPos = Math.min(oldCursorPos, textInputControl.textAreaLength)
+
                 textInputControl.cursorPosition = cursorPos
             }
             else {
                 textInputControl.text = p_text
             }
 
-            sendTextChanged = true
+            jsTextChange = false
         }
     }
 

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -8,7 +8,7 @@ Item {
     property var textInputManager: null
     property var textInputControl: null
 
-    property string p_text
+    property string p_text : textInputControl ? textInputControl.text : ""
     property color p_color
     property bool p_multiline: false
     property bool p_onChange: false

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -8,7 +8,7 @@ Item {
     property var textInputManager: null
     property var textInputControl: null
 
-    property string p_text: textInputControl ? textInputControl.text : ""
+    property string p_text
     property color p_color
     property bool p_multiline: false
     property bool p_onChange: false
@@ -30,8 +30,22 @@ Item {
 
 
     property var flexbox: React.Flexbox {control: textInputRoot; viewManager: textInputManager}
+    property bool sendTextChanged: true
 
     objectName: p_nativeID
+
+    onP_textChanged: {
+        if(textInputControl) {
+            sendTextChanged = false
+
+            var cursorPos = textInputControl.cursorPosition
+            textInputControl.text = p_text
+            cursorPos = Math.min(cursorPos+1, p_text.length)
+            textInputControl.cursorPosition = cursorPos
+
+            sendTextChanged = true
+        }
+    }
 
     onP_fontWeightChanged: {
         switch(p_fontWeight) {

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+  import QtQuick 2.7
 import QtQuick.Controls 2.2
 import React 0.1 as React
 import  "../js/utils.js" as Utils
@@ -42,7 +42,7 @@ Item {
     objectName: p_nativeID
 
     onP_textChanged: {
-        if(textInputControl /*&& !textInputManager.isUserTextChange(textInputControl, p_text)*/) {
+        if(textInputControl) {
             jsTextChange = true
 
             if(p_multiline) {

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -27,10 +27,21 @@ Item {
     property string p_fontWeight
     property int p_fontWeightEnum
     property bool p_autoFocus: false
-
+    property var p_submitShortcut: p_multiline ? defaultMultilineSubmitShortcut : defaultSingleLineSubmitShortcut
 
     property var flexbox: React.Flexbox {control: textInputRoot; viewManager: textInputManager}
     property bool sendTextChanged: true
+
+    QtObject {
+        id: defaultMultilineSubmitShortcut
+        property string key: "";
+        property var modifiers: []
+    }
+    QtObject {
+        id: defaultSingleLineSubmitShortcut
+        property string key: "Enter";
+        property var modifiers: []
+    }
 
     objectName: p_nativeID
 

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -27,20 +27,16 @@ Item {
     property string p_fontWeight
     property int p_fontWeightEnum
     property bool p_autoFocus: false
-    property var p_submitShortcut: p_multiline ? defaultMultilineSubmitShortcut : defaultSingleLineSubmitShortcut
+    property var p_submitShortcut: defaultShortcut(p_multiline)
 
     property var flexbox: React.Flexbox {control: textInputRoot; viewManager: textInputManager}
     property bool sendTextChanged: true
 
-    QtObject {
-        id: defaultMultilineSubmitShortcut
-        property string key: "";
-        property var modifiers: []
-    }
-    QtObject {
-        id: defaultSingleLineSubmitShortcut
-        property string key: "Enter";
-        property var modifiers: []
+    function defaultShortcut(multiline) {
+        if(multiline)
+            return {key: "", modifiers: []};
+        else
+            return {key: "Enter", modifiers: []};
     }
 
     objectName: p_nativeID

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -38,10 +38,15 @@ Item {
         if(textInputControl) {
             sendTextChanged = false
 
-            var cursorPos = textInputControl.cursorPosition
-            textInputControl.text = p_text
-            cursorPos = Math.min(cursorPos+1, p_text.length)
-            textInputControl.cursorPosition = cursorPos
+            if(p_multiline) {
+                var cursorPos = textInputControl.cursorPosition
+                textInputControl.text = p_text
+                cursorPos = Math.min(cursorPos+1, textInputControl.length)
+                textInputControl.cursorPosition = cursorPos
+            }
+            else {
+                textInputControl.text = p_text
+            }
 
             sendTextChanged = true
         }

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -43,15 +43,21 @@ Flickable {
             }
         }
         onCursorPositionChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
-        Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField,
-                                                            textInputRoot.keyText(event.key, event.text),
-                                                            textInputRoot.keyModifiers(event.modifiers))
+        Keys.onPressed: {
+
+            var keyText = textInputRoot.keyText(event.key, event.text);
+            var modifiers = textInputRoot.keyModifiers(event.modifiers);
+            event.accepted = textInputManager.onKeyPressed(textField,
+                                          keyText,
+                                          modifiers,
+                                          textInputRoot.p_submitShortcut.key,
+                                          textInputRoot.p_submitShortcut.modifiers)
+        }
         onContentSizeChanged: {
             if(textInputManager)
                 textInputManager.sendOnContentSizeChange(textField, contentWidth, contentHeight)
         }
         onEditingFinished: {
-            textInputManager.sendOnSubmitEditingToJs(textField)
             textInputManager.sendOnEndEditingToJs(textField)
         }
 

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -7,6 +7,7 @@ import  "../js/utils.js" as Utils
 Flickable {
     id: textField
     property var textInputRoot: parent
+    property alias cursorPosition: textArea.cursorPosition
     property alias text: textArea.text
     anchors.fill: textInputRoot
     ScrollBar.vertical: ScrollBar {}
@@ -14,7 +15,6 @@ Flickable {
     TextArea.flickable: TextArea {
 
         id: textArea
-        text: textInputRoot.p_text
         color: textInputRoot.p_color
         placeholderText: textInputRoot.p_placeholderText
         selectionColor: textInputRoot.p_selectionColor
@@ -37,7 +37,11 @@ Flickable {
             radius: textInputRoot.p_borderRadius
         }
 
-        onTextChanged: textInputRoot.textInputManager.sendTextEditedToJs(textField)
+        onTextChanged: {
+            if(textInputRoot.sendTextChanged) {
+                textInputRoot.textInputManager.sendTextEditedToJs(textField)
+            }
+        }
         onCursorPositionChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
         Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField,
                                                             textInputRoot.keyText(event.key, event.text),

--- a/ReactQt/runtime/src/qml/ReactTextInputArea.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputArea.qml
@@ -9,6 +9,7 @@ Flickable {
     property var textInputRoot: parent
     property alias cursorPosition: textArea.cursorPosition
     property alias text: textArea.text
+    property alias textAreaLength: textArea.length
     anchors.fill: textInputRoot
     ScrollBar.vertical: ScrollBar {}
 
@@ -38,13 +39,12 @@ Flickable {
         }
 
         onTextChanged: {
-            if(textInputRoot.sendTextChanged) {
+            if(!textInputRoot.jsTextChange) {
                 textInputRoot.textInputManager.sendTextEditedToJs(textField)
             }
         }
         onCursorPositionChanged: textInputRoot.textInputManager.sendSelectionChangeToJs(textField)
         Keys.onPressed: {
-
             var keyText = textInputRoot.keyText(event.key, event.text);
             var modifiers = textInputRoot.keyModifiers(event.modifiers);
             event.accepted = textInputManager.onKeyPressed(textField,

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -10,7 +10,6 @@ TextField {
     property var textInputRoot: parent
 
     anchors.fill: textInputRoot
-    text: textInputRoot.p_text
     color: textInputRoot.p_color
     placeholderText: textInputRoot.p_placeholderText
     selectionColor: textInputRoot.p_selectionColor
@@ -32,7 +31,11 @@ TextField {
         radius: textInputRoot.p_borderRadius
     }
 
-    onTextChanged:              textInputManager.sendTextEditedToJs(textField)
+    onTextChanged: {
+        if(textInputRoot.sendTextChanged) {
+            textInputRoot.textInputManager.sendTextEditedToJs(textField)
+        }
+    }
     onCursorPositionChanged:    textInputManager.sendSelectionChangeToJs(textField)
     onAccepted:                 textInputManager.sendOnSubmitEditingToJs(textField)
     onEditingFinished:          textInputManager.sendOnEndEditingToJs(textField)

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -32,7 +32,7 @@ TextField {
     }
 
     onTextChanged: {
-        if(textInputRoot.sendTextChanged) {
+        if(!textInputRoot.jsTextChange) {
             textInputRoot.textInputManager.sendTextEditedToJs(textField)
         }
     }

--- a/ReactQt/runtime/src/qml/ReactTextInputField.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInputField.qml
@@ -37,15 +37,21 @@ TextField {
         }
     }
     onCursorPositionChanged:    textInputManager.sendSelectionChangeToJs(textField)
-    onAccepted:                 textInputManager.sendOnSubmitEditingToJs(textField)
     onEditingFinished:          textInputManager.sendOnEndEditingToJs(textField)
     onContentSizeChanged:       {
         if(textInputManager)
             textInputManager.sendOnContentSizeChange(textField, contentWidth, contentHeight)
     }
-    Keys.onPressed: textInputManager.sendOnKeyPressToJs(textField,
-                                                        textInputRoot.keyText(event.key, event.text),
-                                                        textInputRoot.keyModifiers(event.modifiers))
+    Keys.onPressed: {
+
+        var keyText = textInputRoot.keyText(event.key, event.text);
+        var modifiers = textInputRoot.keyModifiers(event.modifiers);
+        event.accepted = textInputManager.onKeyPressed(textField,
+                                      keyText,
+                                      modifiers,
+                                      textInputRoot.p_submitShortcut.key,
+                                      textInputRoot.p_submitShortcut.modifiers)
+    }
 
     onFocusChanged: {
         if (focus) {


### PR DESCRIPTION
Two TextInput bugs fixed:
1) now TextInput doesn't send "onChange" events when text was set from js side. That solves bug #214
2) I found a discrepancy between multiline and singleline TextInput in Qt. When new text assigned, singleline TextInput saves cursor position, whereas multiline one - doesn't. In second case that results in cursor jumping when we quickly type in text because typed text sent to js and then assigned again from js to Qt because `defaultValue` changed.

PR to check in status-react: https://github.com/status-im/status-react/pull/6176
Here is a code that reveals second problem in js:
```
export default class ButtonReactNative extends Component {

  constructor(props) {
    super(props);
    this.state = { newtext: "" };
  }

  render() {
    return (
      <TextInput
        style={{ backgroundColor: "yellow", width: 300, height: 100 }}
        defaultValue={this.state.newtext}
        multiline={true}
        onChangeText={text => {
          this.setState({ newtext: text })
          console.log("new text: ", text)}
        }
      />
    );
  }
}
```