### PR TITLE
Fix/memory leaks

### DIFF
--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -92,11 +92,12 @@ void ScrollViewManager::updateListViewItem(QQuickItem* item, QQuickItem* child, 
     QQmlProperty::write(scrollView, "model", QVariant::fromValue(model.data()));
 }
 
-void ScrollViewManager::removeListViewItem(QQuickItem* item,
-                                           const QList<int>& removeAtIndices,
-                                           bool unregisterAndDelete) {
+QList<QQuickItem*> ScrollViewManager::removeListViewItems(QQuickItem* item, const QList<int>& removeAtIndices) {
+
+    QList<QQuickItem*> removedChildren;
+
     if (removeAtIndices.isEmpty())
-        return;
+        return removedChildren;
 
     QQuickItem* scrollView = m_scrollViewByListViewItem[item];
     ScrollViewModelPtr model = m_modelByScrollView[scrollView];
@@ -104,14 +105,12 @@ void ScrollViewManager::removeListViewItem(QQuickItem* item,
     foreach (int idxToRemote, removeAtIndices) {
         QQuickItem* itemToRemove = model->takeAt(idxToRemote).value<QQuickItem*>();
         itemToRemove->setParentItem(nullptr);
-
-        if (unregisterAndDelete) {
-            itemToRemove->setParent(nullptr);
-            itemToRemove->deleteLater();
-        }
+        removedChildren.push_back(itemToRemove);
     }
 
     utilities::removeFlexboxChilds(item, removeAtIndices);
+
+    return removedChildren;
 }
 
 QQuickItem* ScrollViewManager::scrollViewContentItem(QQuickItem* item, int position) {

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -39,8 +39,7 @@ public:
 
     static bool isArrayScrollingOptimizationEnabled(QQuickItem* item);
     static void updateListViewItem(QQuickItem* item, QQuickItem* child, int position);
-    static void
-    removeListViewItem(QQuickItem* item, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
+    static QList<QQuickItem*> removeListViewItems(QQuickItem* item, const QList<int>& removeAtIndices);
     static QQuickItem* scrollViewContentItem(QQuickItem* item, int position);
 
 public Q_SLOTS:

--- a/ReactQt/runtime/src/qml/ReactScrollListView.qml
+++ b/ReactQt/runtime/src/qml/ReactScrollListView.qml
@@ -42,10 +42,6 @@ ListView{
             model.display.parent = componentId
             model.display.anchors.centerIn = componentId
         }
-
-        Component.onDestruction: {
-            model.display.parent = null
-        }
     }
 
     onFlickingChanged: {

--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -77,7 +77,11 @@ TextEdit {
         subscribeToChildrenTextChanges()
         updateHtmlText()
     }
-    onParentChanged: updateHtmlText()
+    onParentChanged: {
+        if(parent){
+            updateHtmlText()
+        }
+    }
 
     function manageFlexbox() {
         //Only topmost text item in a set of nested ones can have a flexbox node.

--- a/ReactQt/runtime/src/qml/ReactText.qml
+++ b/ReactQt/runtime/src/qml/ReactText.qml
@@ -86,7 +86,7 @@ TextEdit {
     function manageFlexbox() {
         //Only topmost text item in a set of nested ones can have a flexbox node.
         if(textIsTopInBlock) {
-            textRoot.flexbox = Qt.createQmlObject('import React 0.1 as React; React.Flexbox {control: textRoot; viewManager: textManager}',
+            textRoot.flexbox = Qt.createQmlObject('import React 0.1 as React; React.Flexbox {control: textRoot; viewManager: (textManager ? textManager : null)}',
                                                textRoot, "dynamicSnippet1");
         }
         else

--- a/ReactQt/runtime/src/uimanager.cpp
+++ b/ReactQt/runtime/src/uimanager.cpp
@@ -105,14 +105,28 @@ void UIManager::removeChildren(QQuickItem* parent, const QList<int>& removeAtInd
             child->setParentItem(nullptr);
 
             if (unregisterAndDelete) {
-                int childTag = AttachedProperties::get(child)->tag();
-                child->setParent(0);
-                m_views.remove(childTag);
+                child->setParent(nullptr);
+                stopTrackingTagsForHierarchy(child);
                 child->deleteLater();
             }
         }
 
         utilities::removeFlexboxChilds(parent, removeAtIndices);
+    }
+}
+
+void UIManager::stopTrackingTagsForHierarchy(QQuickItem* topItem) {
+    const QObjectList& children = topItem->children();
+    for (QObject* child : children) {
+        QQuickItem* quickItemChild = qobject_cast<QQuickItem*>(child);
+        if (quickItemChild) {
+            stopTrackingTagsForHierarchy(quickItemChild);
+        }
+    }
+    AttachedProperties* ap = AttachedProperties::get(topItem);
+    if (ap) {
+        int childTag = ap->tag();
+        m_views.remove(childTag);
     }
 }
 

--- a/ReactQt/runtime/src/uimanager.h
+++ b/ReactQt/runtime/src/uimanager.h
@@ -87,6 +87,7 @@ public:
 
 private:
     void removeChildren(QQuickItem* parent, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
+    void stopTrackingTagsForHierarchy(QQuickItem* topItem);
 
 private:
     static int m_nextRootTag;

--- a/ReactQt/runtime/src/uimanager.h
+++ b/ReactQt/runtime/src/uimanager.h
@@ -84,10 +84,11 @@ public:
     void registerRootView(QQuickItem* root);
 
     QQuickItem* viewForTag(int reactTag);
+    void stopTrackingTagsForHierarchy(QQuickItem* topItem);
 
 private:
-    void removeChildren(QQuickItem* parent, const QList<int>& removeAtIndices, bool unregisterAndDelete = true);
-    void stopTrackingTagsForHierarchy(QQuickItem* topItem);
+    QList<QQuickItem*> removeChildrenFromVisualParent(QQuickItem* parent, const QList<int>& removeAtIndices);
+    void destroyComponents(const QList<QQuickItem*> items);
 
 private:
     static int m_nextRootTag;

--- a/ReactQt/runtime/src/utilities.cpp
+++ b/ReactQt/runtime/src/utilities.cpp
@@ -117,9 +117,11 @@ void insertChildItemAt(QQuickItem* item, int position, QQuickItem* parent) {
     if (childItems.size() && childItems.size() > position) {
         QQuickItem* nextItem = childItems.at(position);
         item->setParentItem(parent);
+        item->setParent(parent);
         item->stackBefore(nextItem);
     } else {
         item->setParentItem(parent);
+        item->setParent(parent);
     }
 }
 


### PR DESCRIPTION
Partially fixes #348

Qml visual hierarchy differs from memory management hierarchy. So when we add new component it should be added to both. Then after deletion of top element, all childs also removed.

Steps to test with example in #348:
- run app (83Mb consumes at start)
- click on "click me" 30 times
result before: 240Mb consumed
result after: 97Mb consumed
