### PR TITLE
Minor changes for Windows cross-compilation

### DIFF
--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(
 
 set(USED_QT_MODULES Core Qml Quick WebSockets Svg Concurrent)
 if (USE_QTWEBKIT)
-  set (USED_QT_MODULES ${USED_QT_MODULES} Webkit)
+  set(USED_QT_MODULES ${USED_QT_MODULES} WebKit)
 endif()
 
 qt5_use_modules(${APP_NAME} ${USED_QT_MODULES})
@@ -81,4 +81,8 @@ target_link_libraries(
 
 if (REACT_NATIVE_DESKTOP_MAIN_APP_EXTERNAL_PROJECT_DEPS)
   target_link_libraries(${APP_NAME} ${REACT_NATIVE_DESKTOP_MAIN_APP_EXTERNAL_PROJECT_DEPS})
+endif()
+
+if (REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS)
+  target_link_libraries(${APP_NAME} ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS})
 endif()

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -252,7 +252,7 @@ include_directories(${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS})
 
 set(USED_QT_MODULES Core Qml Quick WebSockets Svg Concurrent)
 if (USE_QTWEBKIT)
-  set (USED_QT_MODULES ${USED_QT_MODULES} Webkit)
+  set (USED_QT_MODULES ${USED_QT_MODULES} WebKit)
 endif()
 
 qt5_use_modules(react-native ${USED_QT_MODULES})


### PR DESCRIPTION
This PR makes some minor fixes required for [Windows cross-compilation](https://github.com/status-im/status-react/issues/5807):
- Casing of WebKit (otherwise the file is not found on Linux)
- Link the `REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS` libraries the app (otherwise things like Qt5Core are reported missing in the link step)