### PR TITLE
Make app a GUI app when building bundle and add app icon

### DIFF
--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -38,6 +38,13 @@ if (JS_BUNDLE_PATH)
   set(JS_BUNDLE_RESOURCE "<file alias=\"index.desktop.bundle\">${JS_BUNDLE_PATH}</file>")
 endif()
 
+if (BUILD_FOR_BUNDLE)
+  # Set some Win32 Specific Settings
+  if (WIN32)
+    set(GUI_TYPE WIN32)
+  endif(WIN32)
+endif(BUILD_FOR_BUNDLE)
+
 configure_file(
   main.qml.in
   ${CMAKE_CURRENT_SOURCE_DIR}/main.qml
@@ -58,11 +65,12 @@ endif()
 if (APPLICATION_MAIN_CPP_PATH)
   set(MAIN_CPP_SOURCE ${APPLICATION_MAIN_CPP_PATH})
 else()
-set(MAIN_CPP_SOURCE main.cpp)
+  set(MAIN_CPP_SOURCE main.cpp)
 endif()
 
 add_executable(
   ${APP_NAME}
+  ${GUI_TYPE}
   ${MAIN_CPP_SOURCE}
   main.qrc
 )

--- a/ReactQt/application/src/CMakeLists.txt
+++ b/ReactQt/application/src/CMakeLists.txt
@@ -37,6 +37,7 @@ string (REPLACE ";" "," EXTERNAL_MODULES "${REACT_NATIVE_DESKTOP_EXTERNAL_MODULE
 if (JS_BUNDLE_PATH)
   set(JS_BUNDLE_RESOURCE "<file alias=\"index.desktop.bundle\">${JS_BUNDLE_PATH}</file>")
 endif()
+set(ICON_PNG_RESOURCE "<file alias=\"icon.png\">${ICON_PNG_RESOURCE_PATH}</file>")
 
 if (BUILD_FOR_BUNDLE)
   # Set some Win32 Specific Settings
@@ -68,11 +69,16 @@ else()
   set(MAIN_CPP_SOURCE main.cpp)
 endif()
 
+if (APPLICATION_MAIN_RC_PATH)
+  set(MAIN_RC_PATH ${APPLICATION_MAIN_RC_PATH})
+endif()
+
 add_executable(
   ${APP_NAME}
   ${GUI_TYPE}
   ${MAIN_CPP_SOURCE}
   main.qrc
+  ${MAIN_RC_PATH}
 )
 
 set(USED_QT_MODULES Core Qml Quick WebSockets Svg Concurrent)

--- a/ReactQt/application/src/main.qrc.in
+++ b/ReactQt/application/src/main.qrc.in
@@ -13,5 +13,6 @@
     <file>main.qml</file>
     ${JS_BUNDLE_RESOURCE}
     ${FONTS_RESOURCE}
+    ${ICON_PNG_RESOURCE}
   </qresource>
 </RCC>

--- a/ReactQt/runtime/src/logger.cpp
+++ b/ReactQt/runtime/src/logger.cpp
@@ -34,7 +34,7 @@ const QSettings& Logger::settings() {
 
 void Logger::registerModule(const QString& moduleName) {
     if (!m_settings->contains(moduleName)) {
-        m_settings->setValue(moduleName, true);
+        m_settings->setValue(moduleName, false);
     }
 }
 


### PR DESCRIPTION
This PR passes `WIN32` parameter to `add_executable` on Windows so that a GUI app is generated instead of a console app. It also adds an app icon to Windows and Linux.

Part of https://github.com/status-im/status-react/issues/5807