### PR TITLE
Fixed incorrect positioning of buttons in Alert dialog

### DIFF
--- a/ReactQt/runtime/src/qml/ReactAlert.qml
+++ b/ReactQt/runtime/src/qml/ReactAlert.qml
@@ -70,20 +70,27 @@ Item {
             wrapMode: Text.WordWrap
         }
 
-        footer: DialogButtonBox {
-            Repeater {
-                model: buttons
-                delegate:  Button {
-                    text: buttons[index].text
-                    property var name: buttons[index].name
-                    DialogButtonBox.buttonRole: buttonRole(buttons[index].role)
-                 }
-            }
-            onClicked: {
-                root.closedByButton = true;
-                root.alertManager.sendButtonClickToJs(callback, button.name)
-                dialog.accept();
-            }
+        footer: createButtonBox(buttons)
+
+        function createButtonBox(buttons) {
+            return Qt.createQmlObject('
+                                    import QtQuick 2.4
+                                    import QtQuick.Controls 2.2
+                                    DialogButtonBox {
+                                        Repeater {
+                                            model: buttons
+                                            delegate:  Button {
+                                                text: buttons[index].text
+                                                property var name: buttons[index].name
+                                                DialogButtonBox.buttonRole: buttonRole(buttons[index].role)
+                                            }
+                                         }
+                                         onClicked: {
+                                             root.closedByButton = true;
+                                             root.alertManager.sendButtonClickToJs(callback, button.name)
+                                             dialog.accept();
+                                         }
+                                     }',dialog, "dynamicButtonBox");
         }
     }
 


### PR DESCRIPTION
Fixes #362

It appeared that Qt has a bug in `DialogButtonBox` component. When you use `Repeater` to create buttons within `DialogButtonBox` you shouldn't change model of the repeater. Otherwise position of buttons will be broken. 
This is our case because we need to create buttons from model and that model changes from js.
So to avoid problem the DialogButtonBox now creates dynamically when button model changed.