### PR TITLE
add example of setting the CMAKE_PREFIX_PATH within root CMakeLists.txt

### DIFF
--- a/Development-linux.md
+++ b/Development-linux.md
@@ -30,6 +30,14 @@ Install:
 Launch `Qt Creator`, select `Tools`->`Options..`->`Build & Run`->`CMake` tab.
 Make sure that `CMake` tool is auto-detected by `Qt Creator` or add one manually.
 
+It may be necessary to add:
+
+```
+set(CMAKE_PREFIX_PATH "<path_to_Qt>/5.9.1/gcc_64/lib/cmake")
+```
+
+to the root `CMakeLists.txt` file in `react-native-desktop` repo in order for QtCreator to find the necessary packages.
+
 ### Build react-native-desktop with Qt Creator
 
 In `Qt Creator` select menu `File`->`Open File or Project...`.  

--- a/Development-linux.md
+++ b/Development-linux.md
@@ -33,7 +33,7 @@ Make sure that `CMake` tool is auto-detected by `Qt Creator` or add one manually
 It may be necessary to add:
 
 ```
-set(CMAKE_PREFIX_PATH "<path_to_Qt>/5.9.1/gcc_64/lib/cmake")
+set(CMAKE_PREFIX_PATH "<path_to_Qt>/5.11.2/gcc_64/lib/cmake")
 ```
 
 to the root `CMakeLists.txt` file in `react-native-desktop` repo in order for QtCreator to find the necessary packages.


### PR DESCRIPTION
## Motivation

related to improved documentation around: https://github.com/status-im/react-native-desktop/issues/383

using QtCreator on Linux without this path explicitly set was causing compilation errors when attempting to build the project. If it is better to set this var elsewhere (or not at all) please let me know! 

## CATEGORY
[ DOCS] 
