### PR TITLE
Allow passing initialProps to RN root component

### DIFF
--- a/ReactQt/application/src/main.cpp
+++ b/ReactQt/application/src/main.cpp
@@ -27,6 +27,7 @@ class ReactNativeProperties : public QObject {
     Q_PROPERTY(QUrl codeLocation READ codeLocation WRITE setCodeLocation NOTIFY codeLocationChanged)
     Q_PROPERTY(QString pluginsPath READ pluginsPath WRITE setPluginsPath NOTIFY pluginsPathChanged)
     Q_PROPERTY(QString executor READ executor WRITE setExecutor NOTIFY executorChanged)
+    Q_PROPERTY(QVariantMap initialProps READ initialProps WRITE setInitialProps NOTIFY initialPropsChanged)
 public:
     ReactNativeProperties(QObject* parent = 0) : QObject(parent) {
         m_codeLocation = m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort);
@@ -66,6 +67,15 @@ public:
             return;
         m_executor = executor;
         Q_EMIT executorChanged();
+    }
+    QVariantMap initialProps() const {
+        return m_initialProps;
+    }
+    void setInitialProps(const QVariantMap& initialProps) {
+        if (m_initialProps == initialProps)
+            return;
+        m_initialProps = initialProps;
+        Q_EMIT initialPropsChanged();
     }
     QString packagerHost() const {
         return m_packagerHost;
@@ -107,6 +117,7 @@ Q_SIGNALS:
     void codeLocationChanged();
     void pluginsPathChanged();
     void executorChanged();
+    void initialPropsChanged();
 
 private:
     bool m_liveReload = false;
@@ -117,6 +128,7 @@ private:
     QUrl m_codeLocation;
     QString m_pluginsPath;
     QString m_executor = "LocalServerConnection";
+    QVariantMap m_initialProps;
 };
 
 void loadFontsFromResources() {

--- a/ReactQt/application/src/main.qml
+++ b/ReactQt/application/src/main.qml
@@ -25,5 +25,6 @@ Rectangle {
     pluginsPath: ReactNativeProperties.pluginsPath
     serverConnectionType: ReactNativeProperties.executor
     externalModules: []
+    properties: ReactNativeProperties.initialProps
   }
 }

--- a/ReactQt/application/src/main.qml.in
+++ b/ReactQt/application/src/main.qml.in
@@ -25,5 +25,6 @@ Rectangle {
     pluginsPath: ReactNativeProperties.pluginsPath
     serverConnectionType: ReactNativeProperties.executor
     externalModules: [${EXTERNAL_MODULES}]
+    properties: ReactNativeProperties.initialProps
   }
 }

--- a/local-cli/generator-desktop/templates/ubuntu-server.js
+++ b/local-cli/generator-desktop/templates/ubuntu-server.js
@@ -118,11 +118,12 @@ if (process.argv.indexOf('--pipe') != -1) {
   rnUbuntuServer(process.stdin, process.stdout);
 } else {
   var port = process.env['REACT_SERVER_PORT'] || 5000;
-  process.argv.forEach((val) => {
-    if (val.indexOf('--port') != -1) {
-      port = val.substring(7);
+  process.argv.forEach((val, index) => {
+    if (val == '--port') {
+      port = process.argv[++index];
     }
   });
+
 
   var server = net.createServer((sock) => {
     DEBUG && console.error("-- Connection from RN client");

--- a/ubuntu-server.js
+++ b/ubuntu-server.js
@@ -118,11 +118,12 @@ if (process.argv.indexOf('--pipe') != -1) {
   rnUbuntuServer(process.stdin, process.stdout);
 } else {
   var port = process.env['REACT_SERVER_PORT'] || 5000;
-  process.argv.forEach((val) => {
-    if (val.indexOf('--port') != -1) {
-      port = val.substring(7);
+  process.argv.forEach((val, index) => {
+    if (val == '--port') {
+      port = process.argv[++index];
     }
   });
+
 
   var server = net.createServer((sock) => {
     DEBUG && console.error("-- Connection from RN client");


### PR DESCRIPTION
This will allow setting initialProps in C++ code to be passed to RN's root component, as per 
https://facebook.github.io/react-native/docs/communication-ios#passing-properties-from-native-to-react-native.

PR also includes small change to the way ubuntu-server.js treats `--port` parameter: `--port=5001` is changed to `--port 5001`.