### PR TITLE
Button style changed to have ios look

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -103,7 +103,7 @@ class Button extends React.Component<{
     const buttonStyles = [styles.button];
     const textStyles = [styles.text];
     if (color) {
-      if (Platform.OS === 'ios') {
+      if (Platform.OS === 'ios' || Platform.OS === 'desktop') {
         textStyles.push({color: color});
       } else {
         buttonStyles.push({backgroundColor: color});
@@ -166,6 +166,11 @@ const styles = StyleSheet.create({
       padding: 8,
       fontWeight: '500',
     },
+    desktop: {
+      color: '#007AFF',
+      textAlign: 'center',
+      fontSize: 14,
+    },
   }),
   buttonDisabled: Platform.select({
     ios: {},
@@ -180,6 +185,9 @@ const styles = StyleSheet.create({
     },
     android: {
       color: '#a1a1a1',
+    },
+    desktop: {
+      color: '#cdcdcd',
     },
   }),
 });


### PR DESCRIPTION
Fixes #400

Styling for `Button` changed to look like on ios. `NativeButton` still can be used for native button look. Disabled button now grayed out.

<img width="302" alt="screen shot 2018-11-20 at 5 45 34 pm" src="https://user-images.githubusercontent.com/5786310/48784911-4773ab80-ecec-11e8-9202-a50f4d213fc3.png">
