### PR TITLE
Fixed default TextInput height

### DIFF
--- a/RNTester/js/RNTesterList.desktop.js
+++ b/RNTester/js/RNTesterList.desktop.js
@@ -164,11 +164,11 @@ const ComponentExamples: Array<RNTesterExample> = [
   // },
   {
     key: 'TextExample',
-    module: require('./TextExample.ios'),
+    module: require('./TextExample'),
   },
   {
     key: 'TextInputExample',
-    module: require('./TextInputExample.ios'),
+    module: require('./TextInputExample'),
   },
   {
     key: 'TouchableExample',

--- a/ReactQt/runtime/src/qml/ReactTextInput.qml
+++ b/ReactQt/runtime/src/qml/ReactTextInput.qml
@@ -29,7 +29,11 @@ Item {
     property bool p_autoFocus: false
     property var p_submitShortcut: defaultShortcut(p_multiline)
 
-    property var flexbox: React.Flexbox {control: textInputRoot; viewManager: textInputManager}
+    property var flexbox: React.Flexbox {
+        control: textInputRoot;
+        viewManager: textInputManager
+        p_height: 25
+    }
     property bool jsTextChange: false
 
     function defaultShortcut(multiline) {


### PR DESCRIPTION
Fixes #332 (@siphiuel, please take a look, I'm sure TextInput's `value` property behaves on desktop similarly to mobile.

Also changed links to few RNTester examples that were referencing ios files.