### PR TITLE
Fix NetInfo module

### DIFF
--- a/Libraries/Network/NetInfo.desktop.js
+++ b/Libraries/Network/NetInfo.desktop.js
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Map = require('Map');
+const NativeEventEmitter = require('NativeEventEmitter');
+const NativeModules = require('NativeModules');
+const Platform = require('Platform');
+const RCTNetInfo = NativeModules.NetInfo;
+
+const NetInfoEventEmitter = new NativeEventEmitter(RCTNetInfo);
+
+const DEVICE_CONNECTIVITY_EVENT = 'networkStatusDidChange';
+
+type ChangeEventName = $Enum<{
+  connectionChange: string,
+  change: string,
+}>;
+
+type ReachabilityStateIOS = $Enum<{
+  cell: string,
+  none: string,
+  unknown: string,
+  wifi: string,
+}>;
+
+type ConnectivityStateAndroid = $Enum<{
+  NONE: string,
+  MOBILE: string,
+  WIFI: string,
+  MOBILE_MMS: string,
+  MOBILE_SUPL: string,
+  MOBILE_DUN: string,
+  MOBILE_HIPRI: string,
+  WIMAX: string,
+  BLUETOOTH: string,
+  DUMMY: string,
+  ETHERNET: string,
+  MOBILE_FOTA: string,
+  MOBILE_IMS: string,
+  MOBILE_CBS: string,
+  WIFI_P2P: string,
+  MOBILE_IA: string,
+  MOBILE_EMERGENCY: string,
+  PROXY: string,
+  VPN: string,
+  UNKNOWN: string,
+}>;
+
+const _subscriptions = new Map();
+
+let _isConnectedDeprecated;
+if (Platform.OS === 'ios') {
+  _isConnectedDeprecated = function(
+    reachability: ReachabilityStateIOS,
+  ): boolean {
+    return reachability !== 'none' && reachability !== 'unknown';
+  };
+} else if (Platform.OS === 'android') {
+  _isConnectedDeprecated = function(
+    connectionType: ConnectivityStateAndroid,
+  ): boolean {
+    return connectionType !== 'NONE' && connectionType !== 'UNKNOWN';
+  };
+}
+
+function _isConnected(connection) {
+  return connection.type !== 'none' && connection.type !== 'unknown';
+}
+
+const _isConnectedSubscriptions = new Map();
+
+/**
+ * NetInfo exposes info about online/offline status.
+ *
+ * See https://facebook.github.io/react-native/docs/netinfo.html
+ */
+const NetInfo = {
+  /**
+   * Adds an event handler.
+   *
+   * See https://facebook.github.io/react-native/docs/netinfo.html#addeventlistener
+   */
+  addEventListener(
+    eventName: ChangeEventName,
+    handler: Function,
+  ): {remove: () => void} {
+    let listener;
+    if (eventName === 'connectionChange') {
+      listener = NetInfoEventEmitter.addListener(
+        DEVICE_CONNECTIVITY_EVENT,
+        appStateData => {
+          handler({
+            type: appStateData.connectionType,
+            effectiveType: appStateData.effectiveConnectionType,
+          });
+        },
+      );
+    } else if (eventName === 'change') {
+      console.warn(
+        'NetInfo\'s "change" event is deprecated. Listen to the "connectionChange" event instead.',
+      );
+
+      listener = NetInfoEventEmitter.addListener(
+        DEVICE_CONNECTIVITY_EVENT,
+        appStateData => {
+          handler(appStateData.network_info);
+        },
+      );
+    } else {
+      console.warn('Trying to subscribe to unknown event: "' + eventName + '"');
+      return {
+        remove: () => {},
+      };
+    }
+
+    _subscriptions.set(handler, listener);
+    return {
+      remove: () => NetInfo.removeEventListener(eventName, handler),
+    };
+  },
+
+  /**
+   * Removes the listener for network status changes.
+   *
+   * See https://facebook.github.io/react-native/docs/netinfo.html#removeeventlistener
+   */
+  removeEventListener(eventName: ChangeEventName, handler: Function): void {
+    const listener = _subscriptions.get(handler);
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _subscriptions.delete(handler);
+  },
+
+  /**
+   * This function is deprecated. Use `getConnectionInfo` instead.
+   * Returns a promise that resolves with one of the deprecated connectivity
+   * types:
+   *
+   * The following connectivity types are deprecated. They're used by the
+   * deprecated APIs `fetch` and the `change` event.
+   *
+   * iOS connectivity types (deprecated):
+   * - `none` - device is offline
+   * - `wifi` - device is online and connected via wifi, or is the iOS simulator
+   * - `cell` - device is connected via Edge, 3G, WiMax, or LTE
+   * - `unknown` - error case and the network status is unknown
+   *
+   * Android connectivity types (deprecated).
+   * - `NONE` - device is offline
+   * - `BLUETOOTH` - The Bluetooth data connection.
+   * - `DUMMY` -  Dummy data connection.
+   * - `ETHERNET` - The Ethernet data connection.
+   * - `MOBILE` - The Mobile data connection.
+   * - `MOBILE_DUN` - A DUN-specific Mobile data connection.
+   * - `MOBILE_HIPRI` - A High Priority Mobile data connection.
+   * - `MOBILE_MMS` - An MMS-specific Mobile data connection.
+   * - `MOBILE_SUPL` -  A SUPL-specific Mobile data connection.
+   * - `VPN` -  A virtual network using one or more native bearers. Requires
+   * API Level 21
+   * - `WIFI` - The WIFI data connection.
+   * - `WIMAX` -  The WiMAX data connection.
+   * - `UNKNOWN` - Unknown data connection.
+   *
+   * The rest of the connectivity types are hidden by the Android API, but can
+   * be used if necessary.
+   */
+  fetch(): Promise<any> {
+    console.warn(
+      'NetInfo.fetch() is deprecated. Use NetInfo.getConnectionInfo() instead.',
+    );
+    return RCTNetInfo.getCurrentConnectivity().then(resp => resp.network_info);
+  },
+
+  /**
+   * See https://facebook.github.io/react-native/docs/netinfo.html#getconnectioninfo
+   */
+  getConnectionInfo(): Promise<any> {
+    return RCTNetInfo.getCurrentConnectivity().then(resp => {
+      return {
+        type: resp.connectionType,
+        effectiveType: resp.effectiveConnectionType,
+      };
+    });
+  },
+
+  /**
+   * See https://facebook.github.io/react-native/docs/netinfo.html#getconnectioninfo
+   */
+  setConnectionCheckUrl(url: string): void {
+    RCTNetInfo.setConnectionCheckUrl(url);
+  },
+
+  /**
+   * An object with the same methods as above but the listener receives a
+   * boolean which represents the internet connectivity.
+   *
+   * See https://facebook.github.io/react-native/docs/netinfo.html#isconnected
+   */
+  isConnected: {
+    addEventListener(
+      eventName: ChangeEventName,
+      handler: Function,
+    ): {remove: () => void} {
+      const listener = connection => {
+        if (eventName === 'change') {
+          handler(_isConnectedDeprecated(connection));
+        } else if (eventName === 'connectionChange') {
+          handler(_isConnected(connection));
+        }
+      };
+      _isConnectedSubscriptions.set(handler, listener);
+      NetInfo.addEventListener(eventName, listener);
+      return {
+        remove: () =>
+          NetInfo.isConnected.removeEventListener(eventName, handler),
+      };
+    },
+
+    removeEventListener(eventName: ChangeEventName, handler: Function): void {
+      const listener = _isConnectedSubscriptions.get(handler);
+      NetInfo.removeEventListener(
+        eventName,
+        /* $FlowFixMe(>=0.36.0 site=react_native_fb,react_native_oss) Flow error
+         * detected during the deploy of Flow v0.36.0. To see the error, remove
+         * this comment and run Flow */
+        listener,
+      );
+      _isConnectedSubscriptions.delete(handler);
+    },
+
+    fetch(): Promise<any> {
+      return NetInfo.getConnectionInfo().then(_isConnected);
+    },
+  },
+
+  isConnectionExpensive(): Promise<boolean> {
+    return Platform.OS === 'android'
+      ? RCTNetInfo.isConnectionMetered()
+      : Promise.reject(new Error('Currently not supported on iOS'));
+  },
+};
+
+module.exports = NetInfo;

--- a/RNTester/js/NetInfoExample.js
+++ b/RNTester/js/NetInfoExample.js
@@ -20,16 +20,16 @@ class ConnectionInfoSubscription extends React.Component<{}, $FlowFixMeState> {
   };
 
   componentDidMount() {
-    NetInfo.addEventListener('change', this._handleConnectionInfoChange);
+    NetInfo.addEventListener('connectionChange', this._handleConnectionInfoChange);
   }
 
   componentWillUnmount() {
-    NetInfo.removeEventListener('change', this._handleConnectionInfoChange);
+    NetInfo.removeEventListener('connectionChange', this._handleConnectionInfoChange);
   }
 
   _handleConnectionInfoChange = connectionInfo => {
     const connectionInfoHistory = this.state.connectionInfoHistory.slice();
-    connectionInfoHistory.push(connectionInfo);
+    connectionInfoHistory.push(connectionInfo.type);
     this.setState({
       connectionInfoHistory,
     });
@@ -46,18 +46,18 @@ class ConnectionInfoSubscription extends React.Component<{}, $FlowFixMeState> {
 
 class ConnectionInfoCurrent extends React.Component<{}, $FlowFixMeState> {
   state = {
-    connectionInfo: null,
+    connectionInfo: {type: 'not fetched', effectiveType: 'not fetched'},
   };
 
   componentDidMount() {
-    NetInfo.addEventListener('change', this._handleConnectionInfoChange);
-    NetInfo.fetch().done(connectionInfo => {
+    NetInfo.addEventListener('connectionChange', this._handleConnectionInfoChange);
+    NetInfo.getConnectionInfo().then(connectionInfo => {
       this.setState({connectionInfo});
     });
   }
 
   componentWillUnmount() {
-    NetInfo.removeEventListener('change', this._handleConnectionInfoChange);
+    NetInfo.removeEventListener('connectionChange', this._handleConnectionInfoChange);
   }
 
   _handleConnectionInfoChange = connectionInfo => {
@@ -69,7 +69,8 @@ class ConnectionInfoCurrent extends React.Component<{}, $FlowFixMeState> {
   render() {
     return (
       <View>
-        <Text>{this.state.connectionInfo}</Text>
+        <Text>Type: {this.state.connectionInfo.type}</Text>
+        <Text>Effective type: {this.state.connectionInfo.effectiveType}</Text>
       </View>
     );
   }
@@ -82,7 +83,7 @@ class IsConnected extends React.Component<{}, $FlowFixMeState> {
 
   componentDidMount() {
     NetInfo.isConnected.addEventListener(
-      'change',
+      'connectionChange',
       this._handleConnectivityChange,
     );
     NetInfo.isConnected.fetch().done(isConnected => {
@@ -92,7 +93,7 @@ class IsConnected extends React.Component<{}, $FlowFixMeState> {
 
   componentWillUnmount() {
     NetInfo.isConnected.removeEventListener(
-      'change',
+      'connectionChange',
       this._handleConnectivityChange,
     );
   }

--- a/ReactQt/runtime/src/netinfo.cpp
+++ b/ReactQt/runtime/src/netinfo.cpp
@@ -98,7 +98,6 @@ void NetInfoPrivate::startNetworkAccessMonitoring() {
 
     connect(this, &NetInfoPrivate::networkStateChanged, [=]() {
         if (bridge) {
-            qDebug() << "!! send event";
             bridge->eventDispatcher()->sendDeviceEvent("networkStatusDidChange", networkInfo());
         }
     });

--- a/ReactQt/runtime/src/netinfo.cpp
+++ b/ReactQt/runtime/src/netinfo.cpp
@@ -13,6 +13,9 @@
 
 #include <QDebug>
 #include <QNetworkAccessManager>
+#include <QNetworkConfiguration>
+#include <QNetworkConfigurationManager>
+#include <QNetworkInterface>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimer>
@@ -21,116 +24,106 @@
 
 #include "bridge.h"
 #include "eventdispatcher.h"
+#include "moduleinterface.h"
 #include "netinfo.h"
 
-namespace {
-
-const int NETWORK_REQUEST_TIMEOUT = 3000;
-const int NETWORK_REPLY_CHECK_TIMEOUT = 1000;
-const int MAX_REPLY_CHECK_COUNTER = NETWORK_REQUEST_TIMEOUT / NETWORK_REPLY_CHECK_TIMEOUT;
-} // namespace
+const QString CON_TYPE_NONE = "none";
+const QString CON_TYPE_UNKNOWNN = "unknown";
+const QString CON_TYPE_WIFI = "wifi";
+const QString CON_TYPE_ETHERNET = "ethernet";
+const QString EFCON_TYPE_UNKNOWNN = "unknown";
 
 class NetInfoPrivate : public QObject {
     Q_OBJECT
 public:
-    enum NetworkState { UnkownState = 0, NotAvailable, Available };
-
     NetInfoPrivate();
     ~NetInfoPrivate();
-    void monitorNetworkAccess();
 
-    void setNetworkState(NetworkState state);
+    void startNetworkAccessMonitoring();
+    QVariantMap networkInfo();
+    void setConnectionType(const QString& state);
 
+public slots:
+    void checkInterfaces();
+
+public:
+    QNetworkConfigurationManager networkManager;
     Bridge* bridge = nullptr;
-    QTimer requestTimer;
-    QTimer replyTimer;
-    NetworkState networkState = UnkownState;
+    QString connectionType = CON_TYPE_NONE;
+    QString effectiveConnectionType = EFCON_TYPE_UNKNOWNN;
     int replyStateCheckCounter = 0;
 
 Q_SIGNALS:
     void networkStateChanged();
 };
 
-namespace {
-static QMap<NetInfoPrivate::NetworkState, QString> accessibleName{{NetInfoPrivate::UnkownState, "unknown"},
-                                                                  {NetInfoPrivate::NotAvailable, "none"},
-                                                                  {NetInfoPrivate::Available, "wifi"}};
-} // namespace
-
-void NetInfoPrivate::setNetworkState(NetInfoPrivate::NetworkState state) {
-    if (networkState != state) {
-        networkState = state;
+void NetInfoPrivate::setConnectionType(const QString& type) {
+    if (connectionType != type) {
+        connectionType = type;
         Q_EMIT networkStateChanged();
     }
 }
 
-NetInfoPrivate::NetInfoPrivate() {
-    replyTimer.setInterval(NETWORK_REPLY_CHECK_TIMEOUT);
+NetInfoPrivate::NetInfoPrivate() {}
+
+NetInfoPrivate::~NetInfoPrivate() {}
+
+QVariantMap NetInfoPrivate::networkInfo() {
+    return QVariantMap{{"connectionType", connectionType}, {"effectiveConnectionType", effectiveConnectionType}};
 }
 
-NetInfoPrivate::~NetInfoPrivate() {
-    requestTimer.stop();
-    replyTimer.stop();
-}
+void NetInfoPrivate::checkInterfaces() {
+    auto type = CON_TYPE_NONE;
 
-void NetInfoPrivate::monitorNetworkAccess() {
-    if (requestTimer.isActive())
-        return;
-    QObject::connect(this, &NetInfoPrivate::networkStateChanged, [=]() {
-        bridge->eventDispatcher()->sendDeviceEvent("networkStatusDidChange",
-                                                   QVariantMap{{"connectionType", accessibleName.value(networkState)}});
-    });
+    foreach (QNetworkInterface interface, QNetworkInterface::allInterfaces()) {
+        bool interfaceUp = interface.flags().testFlag(QNetworkInterface::IsUp);
+        bool interfaceNotLoopback = !interface.flags().testFlag(QNetworkInterface::IsLoopBack);
+        bool interfaceNotVM = !interface.humanReadableName().contains("VM");
+        bool interfaceMacValid = (interface.hardwareAddress() != "00:00:00:00:00:00");
 
-    QObject::connect(&requestTimer, &QTimer::timeout, [=]() {
-        QNetworkRequest req(QUrl("http://www.google.com"));
-
-        replyStateCheckCounter = 0;
-        replyTimer.start();
-
-        QNetworkReply* reply = bridge->networkAccessManager()->head(req);
-        auto replyFinishOrTimeout = [=]() {
-            auto replyFinishedNoError = reply->isFinished() ? reply->error() == QNetworkReply::NoError : false;
-            auto previousNetworkState = (networkState == NetInfoPrivate::Available);
-
-            if (++replyStateCheckCounter >= MAX_REPLY_CHECK_COUNTER || replyFinishedNoError) {
-                replyTimer.stop();
-
-                if (replyFinishedNoError != previousNetworkState) {
-                    auto newNetworkState =
-                        replyFinishedNoError ? NetInfoPrivate::Available : NetInfoPrivate::NotAvailable;
-                    qDebug() << "monitorNetworkAccess: setNetworkAccessible "
-                             << "old: " << previousNetworkState << "new: " << newNetworkState;
-                    setNetworkState(newNetworkState);
+        if (interfaceUp && interfaceNotLoopback && interfaceNotVM)
+            foreach (QNetworkAddressEntry entry, interface.addressEntries()) {
+                if (interfaceMacValid && entry.ip().toString().contains(".")) {
+                    if (interface.type() == QNetworkInterface::Wifi)
+                        type = CON_TYPE_WIFI;
+                    else if (interface.type() == QNetworkInterface::Ethernet)
+                        type = CON_TYPE_ETHERNET;
                 }
-                reply->deleteLater();
             }
-        };
+    }
+    setConnectionType(type);
+}
 
-        QObject::connect(&replyTimer, &QTimer::timeout, reply, replyFinishOrTimeout);
-        replyTimer.start();
+void NetInfoPrivate::startNetworkAccessMonitoring() {
+
+    connect(this, &NetInfoPrivate::networkStateChanged, [=]() {
+        if (bridge) {
+            qDebug() << "!! send event";
+            bridge->eventDispatcher()->sendDeviceEvent("networkStatusDidChange", networkInfo());
+        }
     });
 
-    requestTimer.start(NETWORK_REQUEST_TIMEOUT);
+    connect(&networkManager, &QNetworkConfigurationManager::updateCompleted, this, &NetInfoPrivate::checkInterfaces);
 }
+
 void NetInfo::getCurrentConnectivity(const ModuleInterface::ListArgumentBlock& resolve,
                                      const ModuleInterface::ListArgumentBlock& reject) {
     Q_UNUSED(reject);
     Q_D(NetInfo);
+    Q_ASSERT(d->bridge);
+
+    resolve(d->bridge, QVariantList{d->networkInfo()});
 }
 
-NetInfo::NetInfo(QObject* parent) : QObject(parent), d_ptr(new NetInfoPrivate) {}
+NetInfo::NetInfo(QObject* parent) : QObject(parent), d_ptr(new NetInfoPrivate) {
+    d_ptr->startNetworkAccessMonitoring();
+}
 
 NetInfo::~NetInfo() {}
 
 void NetInfo::setBridge(Bridge* bridge) {
     Q_D(NetInfo);
     d->bridge = bridge;
-
-    connect(d->bridge, &Bridge::jsAppStartedChanged, this, [=]() {
-        if (d->bridge->jsAppStarted()) {
-            d->monitorNetworkAccess();
-        }
-    });
 }
 
 QString NetInfo::moduleName() {

--- a/ReactQt/runtime/src/netinfo.h
+++ b/ReactQt/runtime/src/netinfo.h
@@ -24,6 +24,8 @@ class NetInfo : public QObject, public ModuleInterface {
     Q_INVOKABLE REACT_PROMISE void getCurrentConnectivity(const ModuleInterface::ListArgumentBlock& resolve,
                                                           const ModuleInterface::ListArgumentBlock& reject);
 
+    Q_INVOKABLE void setConnectionCheckUrl(const QString& url);
+
     Q_DECLARE_PRIVATE(NetInfo)
 
 public:


### PR DESCRIPTION
Fixes #378

- `NetInfo` module updated to correspond [documentation](https://facebook.github.io/react-native/docs/netinfo). Deprecated calls not supported.
- RNTester NetInfo example updated: deprecated `change` event substituted with `connectionChange`
- `NetInfo.setConnectionCheckUrl` added for substituting default google pinging with any alternative