### PR TITLE
Added default user-agent to get requests

### DIFF
--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -125,6 +125,7 @@ set(
   asynclocalstorage.cpp
   reactitem.cpp
   rootview.cpp
+  reactnetworkaccessmanager.cpp
   mouseeventsinterceptor.cpp
   testmodule.cpp
   attachedproperties.cpp

--- a/ReactQt/runtime/src/networking.cpp
+++ b/ReactQt/runtime/src/networking.cpp
@@ -87,6 +87,7 @@ void Networking::sendRequest(const QString& method,
 
     QNetworkRequest request(url);
 
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     for (const QString& key : headers.keys()) {
         request.setRawHeader(key.toLocal8Bit(), headers[key].toString().toLocal8Bit());
     }

--- a/ReactQt/runtime/src/reactnetworkaccessmanager.cpp
+++ b/ReactQt/runtime/src/reactnetworkaccessmanager.cpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "reactnetworkaccessmanager.h"
+
+ReactNetworkAccessManager::ReactNetworkAccessManager(QObject* parent) : QNetworkAccessManager(parent) {}
+
+QNetworkReply* ReactNetworkAccessManager::createRequest(QNetworkAccessManager::Operation op,
+                                                        const QNetworkRequest& originalReq,
+                                                        QIODevice* outgoingData) {
+    QNetworkRequest requestWithHeader = originalReq;
+    requestWithHeader.setRawHeader("User-Agent", "react-native-desktop");
+    return QNetworkAccessManager::createRequest(op, requestWithHeader, outgoingData);
+}
+
+QNetworkAccessManager* ReactNetworkAccessManagerFactory::create(QObject* parent) {
+    return new ReactNetworkAccessManager(parent);
+}
+
+#include "reactnetworkaccessmanager.moc"

--- a/ReactQt/runtime/src/reactnetworkaccessmanager.h
+++ b/ReactQt/runtime/src/reactnetworkaccessmanager.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef REACTNETWORKACCESSMANAGER_H
+#define REACTNETWORKACCESSMANAGER_H
+
+#include <QNetworkAccessManager>
+#include <QQmlNetworkAccessManagerFactory>
+
+class ReactNetworkAccessManager : public QNetworkAccessManager {
+    Q_OBJECT
+
+public:
+    ReactNetworkAccessManager(QObject* parent = nullptr);
+
+protected:
+    virtual QNetworkReply* createRequest(QNetworkAccessManager::Operation op,
+                                         const QNetworkRequest& originalReq,
+                                         QIODevice* outgoingData = nullptr);
+};
+
+class ReactNetworkAccessManagerFactory : public QQmlNetworkAccessManagerFactory {
+public:
+    QNetworkAccessManager* create(QObject* parent) override;
+};
+
+#endif // REACTNETWORKACCESSMANAGER_H

--- a/ReactQt/runtime/src/rootview.cpp
+++ b/ReactQt/runtime/src/rootview.cpp
@@ -21,6 +21,7 @@
 #include "bridge.h"
 #include "eventdispatcher.h"
 #include "layout/flexbox.h"
+#include "reactnetworkaccessmanager.h"
 #include "rootview.h"
 #include "uimanager.h"
 #include "utilities.h"
@@ -310,6 +311,9 @@ void RootView::componentComplete() {
 #ifdef RCT_DEV
     loadDevMenu();
 #endif // RCT_DEV
+
+    ReactNetworkAccessManagerFactory* networkManagerFactory = new ReactNetworkAccessManagerFactory();
+    qmlEngine(this)->setNetworkAccessManagerFactory(networkManagerFactory);
 
     QTimer::singleShot(0, [=]() {
         // TODO: setQmlEngine && setNetworkAccessManager to be just setQmlEngine && then internal?


### PR DESCRIPTION
Qt has an issue with retrieving data from some servers because it doesn't add `user-agent` field to get requests.
This PR fixes that.