### PR TITLE
Different optimizations

### DIFF
--- a/ReactQt/runtime/src/componentdata.cpp
+++ b/ReactQt/runtime/src/componentdata.cpp
@@ -65,22 +65,23 @@ QVariantMap ComponentData::viewConfig() const {
     QStringList bubblingEvents;
 
     // {{{ propTypes
-    QMap<QString, QMetaProperty> properties = ph->availableProperties();
+    QMap<QString, QString> properties = ph->availableProperties();
 
     // XXX: sort out the callback events..
     QVariantMap propTypes;
     for (auto& propName : properties.keys()) {
-        auto pName = propName;
-        auto p = properties.value(propName);
+        auto qmlPropName = properties[propName];
+
+        QMetaProperty p = ph->metaProperty(propName);
 
         if (p.userType() == qMetaTypeId<ModuleInterface::BubblingEventBlock>()) {
-            propTypes.insert(p.name(), "bool");
-            bubblingEvents << p.name();
+            propTypes.insert(qmlPropName, "bool");
+            bubblingEvents << qmlPropName;
         } else if (p.userType() == qMetaTypeId<ModuleInterface::DirectEventBlock>()) {
-            propTypes.insert(p.name(), "bool");
-            directEvents << p.name();
+            propTypes.insert(qmlPropName, "bool");
+            directEvents << qmlPropName;
         } else {
-            propTypes.insert(pName, p.typeName());
+            propTypes.insert(propName, p.typeName());
         }
     }
 

--- a/ReactQt/runtime/src/componentmanagers/imageloader.cpp
+++ b/ReactQt/runtime/src/componentmanagers/imageloader.cpp
@@ -25,13 +25,13 @@
 class ImageLoaderPrivate {
 
 public:
-    QIODevice* cachedData(const QUrl& source) {
+    QIODevice* cachedImageData(const QUrl& source) {
         auto cache = qobject_cast<QNetworkDiskCache*>(bridge->networkAccessManager()->cache());
         return cache->data(source);
     }
 
     bool isCached(const QUrl& source) {
-        auto cached = cachedData(source);
+        auto cached = cachedImageData(source);
         cached->deleteLater();
         return (cached != nullptr);
     }
@@ -76,6 +76,7 @@ public:
         });
     }
 
+public:
     Bridge* bridge = nullptr;
 };
 
@@ -96,9 +97,9 @@ void ImageLoader::getSize(const QString& url, double success, double error) {
     Q_D(ImageLoader);
     d->fetchImage(url, [=](ImageLoader::Event event, const QVariantMap& data) {
         if (event == ImageLoader::Event_LoadSuccess) {
-            if (d->isCached(url)) {
+            auto data = d->cachedImageData(url);
+            if (data) {
                 QSize size;
-                auto data = d->cachedData(url);
                 data->deleteLater();
                 size = QImage::fromData(data->readAll()).size();
                 d->bridge->invokePromiseCallback(

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.h
@@ -54,6 +54,7 @@ private Q_SLOTS:
     void scrollBeginDrag();
     void scrollEndDrag();
     void scroll();
+    void onDraggingChanged();
 
 private:
     QVariantMap buildEventData(QQuickItem* item) const;
@@ -63,6 +64,7 @@ private:
 
     static QMap<QQuickItem*, QQuickItem*> m_scrollViewByListViewItem;
     static QMap<QQuickItem*, ScrollViewModelPtr> m_modelByScrollView;
+    static QMap<QQuickItem*, QTimer*> m_scrollTimers;
 };
 
 #endif // SCROLLVIEWMANAGER_H

--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -40,8 +40,8 @@ PropertyHandler* TextManager::propertyHandler(QObject* object) {
 
     // we keep track of all assigned properties because if property not assigned explicitly,
     // it should be taken from parent
-    return new PropertyHandler(object, [&](QObject* object, QMetaProperty property, const QVariant& value) {
-        m_explicitlySetProps[object].insert(property.name());
+    return new PropertyHandler(object, [&](QObject* object, const QString& propertyName, const QVariant&) {
+        m_explicitlySetProps[object].insert(propertyName);
     });
 }
 

--- a/ReactQt/runtime/src/layout/flexbox.cpp
+++ b/ReactQt/runtime/src/layout/flexbox.cpp
@@ -170,16 +170,18 @@ void FlexboxPrivate::updatePropertiesForControl(YGNodeRef node) {
     auto qmlControl = static_cast<FlexboxPrivate*>(YGNodeGetContext(node))->m_control;
     auto viewManager = static_cast<FlexboxPrivate*>(YGNodeGetContext(node))->m_viewManager;
 
-    bool emitLayoutUpdated =
-        YGNodeLayoutGetLeft(node) != qmlControl->x() || YGNodeLayoutGetTop(node) != qmlControl->y() ||
-        YGNodeLayoutGetWidth(node) != qmlControl->width() || YGNodeLayoutGetHeight(node) != qmlControl->height();
+    bool layoutUpdated = YGNodeLayoutGetLeft(node) != qmlControl->x() || YGNodeLayoutGetTop(node) != qmlControl->y() ||
+                         YGNodeLayoutGetWidth(node) != qmlControl->width() ||
+                         YGNodeLayoutGetHeight(node) != qmlControl->height();
 
-    qmlControl->setX(YGNodeLayoutGetLeft(node));
-    qmlControl->setY(YGNodeLayoutGetTop(node));
-    qmlControl->setWidth(YGNodeLayoutGetWidth(node));
-    qmlControl->setHeight(YGNodeLayoutGetHeight(node));
+    if (layoutUpdated) {
+        qmlControl->setX(YGNodeLayoutGetLeft(node));
+        qmlControl->setY(YGNodeLayoutGetTop(node));
+        qmlControl->setWidth(YGNodeLayoutGetWidth(node));
+        qmlControl->setHeight(YGNodeLayoutGetHeight(node));
+    }
 
-    if (emitLayoutUpdated && viewManager) {
+    if (layoutUpdated && viewManager) {
         viewManager->sendOnLayoutToJs(qmlControl,
                                       YGNodeLayoutGetLeft(node),
                                       YGNodeLayoutGetTop(node),

--- a/ReactQt/runtime/src/propertyhandler.h
+++ b/ReactQt/runtime/src/propertyhandler.h
@@ -18,13 +18,36 @@
 
 #include <QMap>
 #include <QMetaProperty>
+#include <QMutex>
 #include <QObject>
 
 class QQuickItem;
 class Flexbox;
 const QString QML_PROPERTY_PREFIX = "p_";
 
-using SetPropertyCallback = std::function<void(QObject* object, QMetaProperty property, const QVariant& value)>;
+struct Props {
+
+    Props() {
+        m_qmlProperties = new QMap<QString, QString>();
+        m_flexboxProperties = new QMap<QString, QString>();
+        m_defaultQmlValues = new QMap<QString, QVariant>();
+        m_defaultFlexboxValues = new QMap<QString, QVariant>();
+    };
+
+    ~Props() {
+        delete m_qmlProperties;
+        delete m_flexboxProperties;
+        delete m_defaultQmlValues;
+        delete m_defaultFlexboxValues;
+    }
+
+    QMap<QString, QString>* m_qmlProperties = nullptr;
+    QMap<QString, QString>* m_flexboxProperties = nullptr;
+    QMap<QString, QVariant>* m_defaultQmlValues = nullptr;
+    QMap<QString, QVariant>* m_defaultFlexboxValues = nullptr;
+};
+
+using SetPropertyCallback = std::function<void(QObject* object, const QString& propertyName, const QVariant& value)>;
 
 class PropertyHandler : public QObject {
     Q_OBJECT
@@ -33,28 +56,32 @@ public:
     PropertyHandler(QObject* object, SetPropertyCallback callback = SetPropertyCallback());
     virtual ~PropertyHandler();
 
-    virtual QMap<QString, QMetaProperty> availableProperties();
+    virtual QMap<QString, QString> availableProperties();
     virtual void applyProperties(const QVariantMap& properties);
-    QVariant value(const QString& propertyName);
+    QMetaProperty metaProperty(const QString& propertyName);
 
 private:
     void buildPropertyMap();
     void setValueToObjectProperty(QObject* object,
-                                  QMetaProperty property,
+                                  const QString& property,
+                                  const QString& qmlPropertyName,
                                   const QVariant& value,
                                   const QVariant& defaultValue);
     void getPropertiesFromObject(const QObject* object,
-                                 QMap<QString, QMetaProperty>& propertiesMap,
-                                 QMap<QString, QVariant>& defaultValuesMap);
+                                 QMap<QString, QString>* propertiesMap,
+                                 QMap<QString, QVariant>* defaultValuesMap);
 
 private:
-    bool m_cached = false;
     QObject* m_object = nullptr;
     Flexbox* m_flexbox = nullptr;
-    QMap<QString, QMetaProperty> m_qmlProperties;
-    QMap<QString, QMetaProperty> m_flexboxProperties;
-    QMap<QString, QVariant> m_defaultQmlValues;
-    QMap<QString, QVariant> m_defaultFlexboxValues;
+    QString m_className;
+
+    const QMap<QString, QString>* qmlProperties();
+    const QMap<QString, QString>* flexboxProperties();
+    const QMap<QString, QVariant>* defaultQmlValues();
+    const QMap<QString, QVariant>* defaultFlexboxValues();
+    static QMap<QString, Props*> m_propsForClass;
+
     SetPropertyCallback m_setPropertyCallback;
 };
 

--- a/ReactQt/runtime/src/qml/ReactImage.qml
+++ b/ReactQt/runtime/src/qml/ReactImage.qml
@@ -47,6 +47,7 @@ React.Item {
         //blurry when resized. To avoid this we set sourceSize that supercedes internal svg settings
         sourceSize.width: isSVG ? flexbox.p_width : undefined
         sourceSize.height: isSVG ? flexbox.p_height : undefined
+        asynchronous: true
     }
 
     FastBlur {


### PR DESCRIPTION
Optimizations made to make react-native-desktop faster:
- images load asynchronously
- propertyhandler doesn't generate a list of properties for every object, only once for class
- reduced amount of calls to image cache