### PR TITLE
InstallPrerequisites: fix `E: Package 'nodejs-legacy' has no installa…

### DIFF
--- a/docs/InstallPrerequisites.md
+++ b/docs/InstallPrerequisites.md
@@ -25,7 +25,7 @@ Download and run [Qt 5.11.2](https://download.qt.io/archive/qt/5.11/5.11.2/qt-op
 ### Ubuntu
 
 ```
-sudo apt-get install -y git cmake nodejs-legacy npm
+sudo apt-get install -y git cmake nodejs npm
 ```
 
 Download and run [Qt 5.11.2](https://download.qt.io/archive/qt/5.11/5.11.2/qt-opensource-linux-x64-5.11.2.run) installer for Linux. Finish installation process.


### PR DESCRIPTION
```
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package nodejs-legacy is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  nodejs libnode64

E: Package 'nodejs-legacy' has no installation candidate
```